### PR TITLE
feat(sdk): add real sign-and-submit wallet methods and tests

### DIFF
--- a/packages/sdk/src/__tests__/submit.test.ts
+++ b/packages/sdk/src/__tests__/submit.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Tests for the sign-and-submit (keypair) overloads of KovaraClient write methods.
+ * Covers issue #93 (SDK tests) and verifies the real wallet integration from issue #94.
+ */
+
+import { KovaraClient } from "../client";
+import * as sdk from "@stellar/stellar-sdk";
+
+const FAKE_XDR = "AAAAfakexdrbase64encodedstring";
+const FAKE_HASH = "deadbeef1234";
+
+// Duck-typed keypair — isKeypair() only checks for a .sign method.
+const fakeKeypair = { sign: jest.fn() };
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const addOperation = jest.fn();
+  const setTimeout = jest.fn();
+  const build = jest.fn();
+  const toEnvelope = jest.fn();
+  const toXDR = jest.fn();
+
+  const MockBuilder = jest.fn(() => ({ addOperation })) as jest.Mock & { fromXDR: jest.Mock };
+  MockBuilder.fromXDR = jest.fn();
+
+  // Wire the TransactionBuilder chain so buildTx() returns a base64 XDR string.
+  addOperation.mockReturnValue({ setTimeout });
+  setTimeout.mockReturnValue({ build });
+  build.mockReturnValue({ toEnvelope });
+  toEnvelope.mockReturnValue({ toXDR });
+  toXDR.mockReturnValue("AAAAfakexdrbase64encodedstring");
+
+  return {
+    rpc: {
+      Server: jest.fn(() => ({
+        simulateTransaction: jest.fn(),
+        prepareTransaction: jest.fn(),
+        sendTransaction: jest.fn(),
+        getTransaction: jest.fn(),
+      })),
+      Api: {
+        isSimulationError: (r: unknown) => !!(r as { error?: unknown }).error,
+        isSimulationSuccess: (r: unknown) => !!(r as { result?: unknown }).result,
+        GetTransactionStatus: {
+          NOT_FOUND: "NOT_FOUND",
+          FAILED: "FAILED",
+          SUCCESS: "SUCCESS",
+        },
+      },
+    },
+    Contract: jest.fn(() => ({ call: jest.fn() })),
+    nativeToScVal: jest.fn((val: unknown, opts?: unknown) => ({
+      _type: "scval",
+      _val: val,
+      _opts: opts,
+    })),
+    scValToNative: jest.fn((scv: unknown) => {
+      const v = (scv as { _val: unknown })._val;
+      if (typeof v === "object" && v !== null && "_type" in (v as object)) {
+        return (v as { _val: unknown })._val;
+      }
+      return v;
+    }),
+    TransactionBuilder: MockBuilder,
+    Account: jest.fn(),
+    Keypair: {
+      random: jest.fn(() => ({ publicKey: () => "GDUMMY", sign: jest.fn() })),
+    },
+    Transaction: jest.fn(),
+    xdr: {},
+  };
+});
+
+/** Helper to get the server instance created by the last KovaraClient constructor */
+function getServerInstance() {
+  const ServerMock = sdk.rpc.Server as unknown as jest.MockedClass<typeof sdk.rpc.Server>;
+  return ServerMock.mock.results[ServerMock.mock.results.length - 1]?.value as {
+    simulateTransaction: jest.Mock;
+    prepareTransaction: jest.Mock;
+    sendTransaction: jest.Mock;
+    getTransaction: jest.Mock;
+  };
+}
+
+function getContractInstance() {
+  const ContractMock = sdk.Contract as unknown as jest.MockedClass<typeof sdk.Contract>;
+  return ContractMock.mock.results[ContractMock.mock.results.length - 1]?.value as {
+    call: jest.Mock;
+  };
+}
+
+describe("KovaraClient submit (sign-and-submit) methods", () => {
+  let client: KovaraClient;
+  let server: ReturnType<typeof getServerInstance>;
+  let preparedTx: { sign: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Re-wire the builder chain after clearAllMocks()
+    const MockBuilder = sdk.TransactionBuilder as unknown as jest.Mock & { fromXDR: jest.Mock };
+    const addOperation = jest.fn();
+    const setTimeoutFn = jest.fn();
+    const build = jest.fn();
+    const toEnvelope = jest.fn();
+    const toXDR = jest.fn();
+    MockBuilder.mockImplementation(() => ({ addOperation }));
+    addOperation.mockReturnValue({ setTimeout: setTimeoutFn });
+    setTimeoutFn.mockReturnValue({ build });
+    build.mockReturnValue({ toEnvelope });
+    toEnvelope.mockReturnValue({ toXDR });
+    toXDR.mockReturnValue(FAKE_XDR);
+
+    // KovaraClient creates its own rpc.Server on each call, but the constructor
+    // call in new KovaraClient() just stores config; Server is created per-call.
+    client = new KovaraClient({
+      contractId: "CDUMMYCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      rpcUrl: "https://dummy-rpc.example.com",
+    });
+
+    // Set up Server mock for the next call
+    preparedTx = { sign: jest.fn() };
+    (sdk.rpc.Server as unknown as jest.Mock).mockImplementation(() => ({
+      simulateTransaction: jest.fn().mockResolvedValue({
+        result: { retval: { _type: "scval", _val: 5 } },
+      }),
+      prepareTransaction: jest.fn().mockResolvedValue(preparedTx),
+      sendTransaction: jest.fn().mockResolvedValue({ status: "PENDING", hash: FAKE_HASH }),
+      getTransaction: jest.fn().mockResolvedValue({ status: "SUCCESS" }),
+    }));
+  });
+
+  describe("submitTx", () => {
+    it("prepares, signs, and sends the transaction", async () => {
+      const MockBuilder = sdk.TransactionBuilder as unknown as jest.Mock & { fromXDR: jest.Mock };
+      MockBuilder.fromXDR = jest.fn().mockReturnValue({ sign: jest.fn() });
+
+      const result = await client.submitTx(fakeKeypair as never, FAKE_XDR);
+
+      expect(MockBuilder.fromXDR).toHaveBeenCalledWith(FAKE_XDR, expect.any(String));
+      server = getServerInstance();
+      expect(server.prepareTransaction).toHaveBeenCalled();
+      expect(preparedTx.sign).toHaveBeenCalledWith(fakeKeypair);
+      expect(server.sendTransaction).toHaveBeenCalled();
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+
+    it("polls until transaction is no longer NOT_FOUND", async () => {
+      const MockBuilder = sdk.TransactionBuilder as unknown as jest.Mock & { fromXDR: jest.Mock };
+      MockBuilder.fromXDR = jest.fn().mockReturnValue({ sign: jest.fn() });
+
+      (sdk.rpc.Server as unknown as jest.Mock).mockImplementation(() => ({
+        simulateTransaction: jest.fn(),
+        prepareTransaction: jest.fn().mockResolvedValue(preparedTx),
+        sendTransaction: jest.fn().mockResolvedValue({ status: "PENDING", hash: FAKE_HASH }),
+        getTransaction: jest
+          .fn()
+          .mockResolvedValueOnce({ status: "NOT_FOUND" })
+          .mockResolvedValueOnce({ status: "SUCCESS" }),
+      }));
+
+      const result = await client.submitTx(fakeKeypair as never, FAKE_XDR);
+      server = getServerInstance();
+      expect(server.getTransaction).toHaveBeenCalledTimes(2);
+      expect(result.txHash).toBe(FAKE_HASH);
+    });
+
+    it("throws when sendTransaction returns ERROR status", async () => {
+      const MockBuilder = sdk.TransactionBuilder as unknown as jest.Mock & { fromXDR: jest.Mock };
+      MockBuilder.fromXDR = jest.fn().mockReturnValue({ sign: jest.fn() });
+
+      (sdk.rpc.Server as unknown as jest.Mock).mockImplementation(() => ({
+        simulateTransaction: jest.fn(),
+        prepareTransaction: jest.fn().mockResolvedValue(preparedTx),
+        sendTransaction: jest.fn().mockResolvedValue({
+          status: "ERROR",
+          errorResult: { result: () => "host invocation failed" },
+        }),
+        getTransaction: jest.fn(),
+      }));
+
+      await expect(client.submitTx(fakeKeypair as never, FAKE_XDR)).rejects.toThrow();
+    });
+
+    it("throws when transaction fails on-chain", async () => {
+      const MockBuilder = sdk.TransactionBuilder as unknown as jest.Mock & { fromXDR: jest.Mock };
+      MockBuilder.fromXDR = jest.fn().mockReturnValue({ sign: jest.fn() });
+
+      (sdk.rpc.Server as unknown as jest.Mock).mockImplementation(() => ({
+        simulateTransaction: jest.fn(),
+        prepareTransaction: jest.fn().mockResolvedValue(preparedTx),
+        sendTransaction: jest.fn().mockResolvedValue({ status: "PENDING", hash: FAKE_HASH }),
+        getTransaction: jest.fn().mockResolvedValue({ status: "FAILED" }),
+      }));
+
+      await expect(client.submitTx(fakeKeypair as never, FAKE_XDR)).rejects.toThrow(
+        "Transaction failed on-chain"
+      );
+    });
+  });
+
+  // For the remaining write-method tests we just need to ensure:
+  // 1. The correct contract method is called with the right args (via Contract.call mock)
+  // 2. submitTx is invoked and returns { txHash }
+
+  function wireSubmit() {
+    const MockBuilder = sdk.TransactionBuilder as unknown as jest.Mock & { fromXDR: jest.Mock };
+    MockBuilder.fromXDR = jest.fn().mockReturnValue({ sign: jest.fn() });
+  }
+
+  describe("createPost with keypair", () => {
+    it("builds, submits, and returns txHash + postId", async () => {
+      wireSubmit();
+      const contract = getContractInstance() ?? { call: jest.fn() };
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => contract);
+
+      const result = await client.createPost(fakeKeypair as never, "GAUTHOR", {
+        author: "GAUTHOR",
+        content: "Hello",
+      });
+
+      expect(result.txHash).toBe(FAKE_HASH);
+      expect(typeof result.postId).toBe("number");
+    });
+  });
+
+  describe("setProfile with keypair", () => {
+    it("builds and submits set_profile", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.setProfile(fakeKeypair as never, "GUSER", {
+        user: "GUSER",
+        username: "alice",
+        creator_token: "GTOKEN",
+      });
+
+      expect(callMock).toHaveBeenCalledWith(
+        "set_profile",
+        expect.objectContaining({ _val: "GUSER" }),
+        expect.objectContaining({ _val: "alice" }),
+        expect.objectContaining({ _val: "GTOKEN" })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("deletePost with keypair", () => {
+    it("builds and submits delete_post", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.deletePost(fakeKeypair as never, "GAUTHOR", 10);
+
+      expect(callMock).toHaveBeenCalledWith(
+        "delete_post",
+        expect.objectContaining({ _val: "GAUTHOR" }),
+        expect.objectContaining({ _val: 10 })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("follow with keypair", () => {
+    it("builds and submits follow", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.follow(fakeKeypair as never, "GFOLLOWER", "GFOLLOWED");
+
+      expect(callMock).toHaveBeenCalledWith(
+        "follow",
+        expect.objectContaining({ _val: "GFOLLOWER" }),
+        expect.objectContaining({ _val: "GFOLLOWED" })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("unfollow with keypair", () => {
+    it("builds and submits unfollow", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.unfollow(fakeKeypair as never, "GFOLLOWER", "GFOLLOWED");
+      expect(callMock).toHaveBeenCalledWith("unfollow", expect.anything(), expect.anything());
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("like with keypair", () => {
+    it("builds and submits like", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.like(fakeKeypair as never, "GLIKER", 3);
+      expect(callMock).toHaveBeenCalledWith(
+        "like",
+        expect.objectContaining({ _val: "GLIKER" }),
+        expect.objectContaining({ _val: 3 })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("unlike with keypair", () => {
+    it("builds and submits unlike", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.unlike(fakeKeypair as never, "GLIKER", 3);
+      expect(callMock).toHaveBeenCalledWith("unlike", expect.anything(), expect.anything());
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("tip with keypair", () => {
+    it("builds and submits tip", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.tip(fakeKeypair as never, "GSENDER", 5, 100n);
+      expect(callMock).toHaveBeenCalledWith(
+        "tip",
+        expect.objectContaining({ _val: "GSENDER" }),
+        expect.objectContaining({ _val: 5 }),
+        expect.objectContaining({ _val: 100n })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("block/unblock with keypair", () => {
+    it("builds and submits block", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.block(fakeKeypair as never, "GBLOCKER", "GBLOCKED");
+      expect(callMock).toHaveBeenCalledWith(
+        "block",
+        expect.objectContaining({ _val: "GBLOCKER" }),
+        expect.objectContaining({ _val: "GBLOCKED" })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+
+    it("builds and submits unblock", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.unblock(fakeKeypair as never, "GBLOCKER", "GBLOCKED");
+      expect(callMock).toHaveBeenCalledWith("unblock", expect.anything(), expect.anything());
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("createPool with keypair", () => {
+    it("builds and submits create_pool", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.createPool(
+        fakeKeypair as never,
+        "GADMIN",
+        "TOKEN",
+        ["GA", "GB"],
+        2
+      );
+      expect(callMock).toHaveBeenCalledWith(
+        "create_pool",
+        expect.objectContaining({ _val: "GADMIN" }),
+        expect.objectContaining({ _val: "TOKEN" }),
+        expect.anything(),
+        expect.objectContaining({ _val: 2 })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("deposit with keypair", () => {
+    it("builds and submits deposit", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.deposit(
+        fakeKeypair as never,
+        "GDEPOSITOR",
+        "pool-1",
+        "TOKEN",
+        500
+      );
+      expect(callMock).toHaveBeenCalledWith(
+        "deposit",
+        expect.objectContaining({ _val: "GDEPOSITOR" }),
+        expect.objectContaining({ _val: "pool-1" }),
+        expect.objectContaining({ _val: "TOKEN" }),
+        expect.objectContaining({ _val: 500 })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+
+  describe("withdraw with keypair", () => {
+    it("builds and submits withdraw", async () => {
+      wireSubmit();
+      const callMock = jest.fn();
+      (sdk.Contract as unknown as jest.Mock).mockImplementation(() => ({ call: callMock }));
+
+      const result = await client.withdraw(
+        fakeKeypair as never,
+        ["GA", "GB"],
+        "pool-1",
+        300,
+        "GRECIPIENT"
+      );
+      expect(callMock).toHaveBeenCalledWith(
+        "withdraw",
+        expect.anything(),
+        expect.objectContaining({ _val: "pool-1" }),
+        expect.objectContaining({ _val: 300 }),
+        expect.objectContaining({ _val: "GRECIPIENT" })
+      );
+      expect(result).toEqual({ txHash: FAKE_HASH });
+    });
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7,6 +7,7 @@ import {
   Account,
   Keypair,
   xdr,
+  Transaction,
 } from "@stellar/stellar-sdk";
 import { Profile, Post, Pool } from "./types";
 import { mapError } from "./errors";
@@ -14,6 +15,13 @@ import { mapError } from "./errors";
 const { isSimulationError, isSimulationSuccess } = rpc.Api;
 
 const DEFAULT_NETWORK = "Test SDF Network ; September 2015";
+
+/** Duck-type guard: treats any object with a `sign` method as a Keypair. */
+function isKeypair(v: unknown): v is Keypair {
+  return (
+    typeof v === "object" && v !== null && typeof (v as Record<string, unknown>).sign === "function"
+  );
+}
 const DEFAULT_TIMEOUT = 30;
 
 function scvAddress(value: string): xdr.ScVal {
@@ -41,8 +49,21 @@ export interface ClientConfig {
   networkPassphrase?: string;
 }
 
+export interface SubmitResult {
+  txHash: string;
+}
+
+export interface CreatePostResult extends SubmitResult {
+  postId: number;
+}
+
 /**
- * Typed client for all Kovara social contract read methods
+ * Typed client for all Kovara social contract methods.
+ *
+ * Write methods accept an optional `Keypair`. When provided the transaction is
+ * signed, submitted to the network, and a `SubmitResult` (or `CreatePostResult`)
+ * is returned. When omitted the raw base64-XDR envelope is returned instead,
+ * preserving the original wallet-agnostic behaviour.
  */
 export class KovaraClient {
   private contractId: string;
@@ -54,6 +75,8 @@ export class KovaraClient {
     this.rpcUrl = config.rpcUrl;
     this.networkPassphrase = config.networkPassphrase || DEFAULT_NETWORK;
   }
+
+  // ─── internals ────────────────────────────────────────────────────────────
 
   private async simulateCall(method: string, ...args: xdr.ScVal[]): Promise<xdr.ScVal | null> {
     const server = new rpc.Server(this.rpcUrl);
@@ -98,9 +121,42 @@ export class KovaraClient {
   }
 
   /**
+   * Signs, submits, and confirms a base64-XDR transaction envelope.
+   * @param keypair - The signing keypair
+   * @param xdrEnvelope - Base64-encoded XDR transaction envelope
+   * @returns The transaction hash
+   */
+  async submitTx(keypair: Keypair, xdrEnvelope: string): Promise<SubmitResult> {
+    const server = new rpc.Server(this.rpcUrl);
+    const tx = TransactionBuilder.fromXDR(xdrEnvelope, this.networkPassphrase) as Transaction;
+
+    // Prepare (simulate + set resource fees) then sign
+    const prepared = await server.prepareTransaction(tx);
+    prepared.sign(keypair);
+
+    const sendResult = await server.sendTransaction(prepared);
+    if (sendResult.status === "ERROR") {
+      throw mapError(sendResult.errorResult?.result().toString() ?? "Transaction failed");
+    }
+
+    // Poll for final status
+    let getResult = await server.getTransaction(sendResult.hash);
+    while (getResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+      await new Promise((r) => setTimeout(r, 1000));
+      getResult = await server.getTransaction(sendResult.hash);
+    }
+
+    if (getResult.status === rpc.Api.GetTransactionStatus.FAILED) {
+      throw mapError("Transaction failed on-chain");
+    }
+
+    return { txHash: sendResult.hash };
+  }
+
+  // ─── read methods ─────────────────────────────────────────────────────────
+
+  /**
    * Fetches a user profile by their address
-   * @param address - The Stellar address of the user
-   * @returns A promise resolving to the user Profile, or null if not found
    */
   async getProfile(address: string): Promise<Profile | null> {
     const retval = await this.simulateCall("get_profile", scvAddress(address));
@@ -112,8 +168,6 @@ export class KovaraClient {
 
   /**
    * Fetches a post by its ID
-   * @param postId - The ID of the post
-   * @returns A promise resolving to the Post data, or null if not found
    */
   async getPost(postId: number): Promise<Post | null> {
     const retval = await this.simulateCall("get_post", scvU64(postId));
@@ -125,7 +179,6 @@ export class KovaraClient {
 
   /**
    * Retrieves the total number of posts created
-   * @returns A promise resolving to the total post count
    */
   async getPostCount(): Promise<number> {
     const retval = await this.simulateCall("get_post_count");
@@ -135,8 +188,6 @@ export class KovaraClient {
 
   /**
    * Fetches the addresses of users that a specific address is following
-   * @param address - The address of the follower
-   * @returns A promise resolving to an array of addresses
    */
   async getFollowing(address: string): Promise<string[]> {
     const retval = await this.simulateCall("get_following", scvAddress(address));
@@ -146,8 +197,6 @@ export class KovaraClient {
 
   /**
    * Fetches the addresses of users following a specific address
-   * @param address - The address of the user being followed
-   * @returns A promise resolving to an array of addresses
    */
   async getFollowers(address: string): Promise<string[]> {
     const retval = await this.simulateCall("get_followers", scvAddress(address));
@@ -157,8 +206,6 @@ export class KovaraClient {
 
   /**
    * Fetches a pool by its ID
-   * @param poolId - The ID of the pool
-   * @returns A promise resolving to the Pool data, or null if not found
    */
   async getPool(poolId: string): Promise<Pool | null> {
     const retval = await this.simulateCall("get_pool", scvString(poolId));
@@ -170,8 +217,6 @@ export class KovaraClient {
 
   /**
    * Retrieves the administrators of a specific pool
-   * @param poolId - The ID of the pool
-   * @returns A promise resolving to an array of admin addresses
    */
   async getPoolAdmins(poolId: string): Promise<string[]> {
     const retval = await this.simulateCall("get_pool_admins", scvString(poolId));
@@ -181,7 +226,6 @@ export class KovaraClient {
 
   /**
    * Fetches the global platform fee in basis points
-   * @returns A promise resolving to the fee in BPS
    */
   async getFeeBps(): Promise<number> {
     const retval = await this.simulateCall("get_fee_bps");
@@ -191,7 +235,6 @@ export class KovaraClient {
 
   /**
    * Fetches the treasury address
-   * @returns A promise resolving to the treasury address
    */
   async getTreasury(): Promise<string> {
     const retval = await this.simulateCall("get_treasury");
@@ -201,9 +244,6 @@ export class KovaraClient {
 
   /**
    * Checks if a specific address has liked a specific post
-   * @param address - The address of the user
-   * @param postId - The ID of the post
-   * @returns A promise resolving to true if liked, false otherwise
    */
   async hasLiked(address: string, postId: number): Promise<boolean> {
     const retval = await this.simulateCall("has_liked", scvAddress(address), scvU64(postId));
@@ -213,9 +253,6 @@ export class KovaraClient {
 
   /**
    * Checks if a user has blocked another user
-   * @param blocker - The address of the user who is blocking
-   * @param blocked - The address of the user who is blocked
-   * @returns A promise resolving to true if blocked, false otherwise
    */
   async isBlocked(blocker: string, blocked: string): Promise<boolean> {
     const retval = await this.simulateCall("is_blocked", scvAddress(blocker), scvAddress(blocked));
@@ -225,8 +262,6 @@ export class KovaraClient {
 
   /**
    * Fetches the number of likes a post has received
-   * @param postId - The ID of the post
-   * @returns A promise resolving to the like count
    */
   async getLikeCount(postId: number): Promise<number> {
     const retval = await this.simulateCall("get_like_count", scvU64(postId));
@@ -234,172 +269,384 @@ export class KovaraClient {
     return Number(scValToNative(retval));
   }
 
+  // ─── write methods ────────────────────────────────────────────────────────
+  //
+  // Each write method has two overloads:
+  //   (a) No keypair → returns base64 XDR string (wallet-agnostic, unchanged behaviour)
+  //   (b) With keypair → signs + submits → returns SubmitResult / CreatePostResult
+
   /**
-   * Builds an XDR envelope for creating a post
-   * @param author - The author's Stellar address
-   * @param content - The post content
-   * @returns The base64-encoded XDR envelope
+   * Creates a post. With a keypair, signs and submits; otherwise returns XDR.
    */
-  createPost(author: string, content: string): string {
-    return this.buildTx("create_post", scvAddress(author), scvString(content));
+  async createPost(
+    keypair: Keypair,
+    author: string,
+    params: { author: string; content: string }
+  ): Promise<CreatePostResult>;
+  createPost(author: string, content: string): string;
+  createPost(
+    keypairOrAuthor: Keypair | string,
+    authorOrContent: string,
+    params?: { author: string; content: string }
+  ): Promise<CreatePostResult> | string {
+    if (isKeypair(keypairOrAuthor) && params) {
+      const xdrEnv = this.buildTx(
+        "create_post",
+        scvAddress(params.author),
+        scvString(params.content)
+      );
+      return this.submitTx(keypairOrAuthor, xdrEnv).then(async (res) => {
+        const count = await this.getPostCount();
+        return { ...res, postId: count };
+      });
+    }
+    return this.buildTx(
+      "create_post",
+      scvAddress(keypairOrAuthor as string),
+      scvString(authorOrContent)
+    );
   }
 
   /**
-   * Builds an XDR envelope for deleting a post
-   * @param author - The author's Stellar address
-   * @param postId - The ID of the post to delete
-   * @returns The base64-encoded XDR envelope
+   * Deletes a post. With a keypair, signs and submits; otherwise returns XDR.
    */
-  deletePost(author: string, postId: number): string {
-    return this.buildTx("delete_post", scvAddress(author), scvU64(postId));
+  async deletePost(keypair: Keypair, author: string, postId: number): Promise<SubmitResult>;
+  deletePost(author: string, postId: number): string;
+  deletePost(
+    keypairOrAuthor: Keypair | string,
+    authorOrPostId: string | number,
+    postId?: number
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrAuthor)) {
+      const xdrEnv = this.buildTx(
+        "delete_post",
+        scvAddress(authorOrPostId as string),
+        scvU64(postId!)
+      );
+      return this.submitTx(keypairOrAuthor, xdrEnv);
+    }
+    return this.buildTx(
+      "delete_post",
+      scvAddress(keypairOrAuthor as string),
+      scvU64(authorOrPostId as number)
+    );
   }
 
   /**
-   * Builds an XDR envelope for following a user
-   * @param follower - The follower's Stellar address
-   * @param followed - The address to follow
-   * @returns The base64-encoded XDR envelope
+   * Follows a user. With a keypair, signs and submits; otherwise returns XDR.
    */
-  follow(follower: string, followed: string): string {
-    return this.buildTx("follow", scvAddress(follower), scvAddress(followed));
+  async follow(keypair: Keypair, follower: string, followed: string): Promise<SubmitResult>;
+  follow(follower: string, followed: string): string;
+  follow(
+    keypairOrFollower: Keypair | string,
+    followerOrFollowed: string,
+    followed?: string
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrFollower)) {
+      const xdrEnv = this.buildTx("follow", scvAddress(followerOrFollowed), scvAddress(followed!));
+      return this.submitTx(keypairOrFollower, xdrEnv);
+    }
+    return this.buildTx(
+      "follow",
+      scvAddress(keypairOrFollower as string),
+      scvAddress(followerOrFollowed)
+    );
   }
 
   /**
-   * Builds an XDR envelope for unfollowing a user
-   * @param follower - The follower's Stellar address
-   * @param followed - The address to unfollow
-   * @returns The base64-encoded XDR envelope
+   * Unfollows a user. With a keypair, signs and submits; otherwise returns XDR.
    */
-  unfollow(follower: string, followed: string): string {
-    return this.buildTx("unfollow", scvAddress(follower), scvAddress(followed));
+  async unfollow(keypair: Keypair, follower: string, followed: string): Promise<SubmitResult>;
+  unfollow(follower: string, followed: string): string;
+  unfollow(
+    keypairOrFollower: Keypair | string,
+    followerOrFollowed: string,
+    followed?: string
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrFollower)) {
+      const xdrEnv = this.buildTx(
+        "unfollow",
+        scvAddress(followerOrFollowed),
+        scvAddress(followed!)
+      );
+      return this.submitTx(keypairOrFollower, xdrEnv);
+    }
+    return this.buildTx(
+      "unfollow",
+      scvAddress(keypairOrFollower as string),
+      scvAddress(followerOrFollowed)
+    );
   }
 
   /**
-   * Builds an XDR envelope for liking a post
-   * @param liker - The liker's Stellar address
-   * @param postId - The ID of the post to like
-   * @returns The base64-encoded XDR envelope
+   * Likes a post. With a keypair, signs and submits; otherwise returns XDR.
    */
-  like(liker: string, postId: number): string {
-    return this.buildTx("like", scvAddress(liker), scvU64(postId));
+  async like(keypair: Keypair, liker: string, postId: number): Promise<SubmitResult>;
+  like(liker: string, postId: number): string;
+  like(
+    keypairOrLiker: Keypair | string,
+    likerOrPostId: string | number,
+    postId?: number
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrLiker)) {
+      const xdrEnv = this.buildTx("like", scvAddress(likerOrPostId as string), scvU64(postId!));
+      return this.submitTx(keypairOrLiker, xdrEnv);
+    }
+    return this.buildTx(
+      "like",
+      scvAddress(keypairOrLiker as string),
+      scvU64(likerOrPostId as number)
+    );
   }
 
   /**
-   * Builds an XDR envelope for unliking a post
-   * @param liker - The liker's Stellar address
-   * @param postId - The ID of the post to unlike
-   * @returns The base64-encoded XDR envelope
+   * Unlikes a post. With a keypair, signs and submits; otherwise returns XDR.
    */
-  unlike(liker: string, postId: number): string {
-    return this.buildTx("unlike", scvAddress(liker), scvU64(postId));
+  async unlike(keypair: Keypair, liker: string, postId: number): Promise<SubmitResult>;
+  unlike(liker: string, postId: number): string;
+  unlike(
+    keypairOrLiker: Keypair | string,
+    likerOrPostId: string | number,
+    postId?: number
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrLiker)) {
+      const xdrEnv = this.buildTx("unlike", scvAddress(likerOrPostId as string), scvU64(postId!));
+      return this.submitTx(keypairOrLiker, xdrEnv);
+    }
+    return this.buildTx(
+      "unlike",
+      scvAddress(keypairOrLiker as string),
+      scvU64(likerOrPostId as number)
+    );
   }
 
   /**
-   * Builds an XDR envelope for tipping a post
-   * @param sender - The sender's Stellar address
-   * @param postId - The ID of the post to tip
-   * @param amount - The tip amount
-   * @returns The base64-encoded XDR envelope
+   * Tips a post. With a keypair, signs and submits; otherwise returns XDR.
    */
-  tip(sender: string, postId: number, amount: number | bigint): string {
-    return this.buildTx("tip", scvAddress(sender), scvU64(postId), scvI128(amount));
+  async tip(
+    keypair: Keypair,
+    sender: string,
+    postId: number,
+    amount: number | bigint
+  ): Promise<SubmitResult>;
+  tip(sender: string, postId: number, amount: number | bigint): string;
+  tip(
+    keypairOrSender: Keypair | string,
+    senderOrPostId: string | number,
+    postIdOrAmount: number | bigint,
+    amount?: number | bigint
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrSender)) {
+      const xdrEnv = this.buildTx(
+        "tip",
+        scvAddress(senderOrPostId as string),
+        scvU64(postIdOrAmount as number),
+        scvI128(amount!)
+      );
+      return this.submitTx(keypairOrSender, xdrEnv);
+    }
+    return this.buildTx(
+      "tip",
+      scvAddress(keypairOrSender as string),
+      scvU64(senderOrPostId as number),
+      scvI128(postIdOrAmount)
+    );
   }
 
   /**
-   * Builds an XDR envelope for creating a pool
-   * @param admin - The admin's Stellar address
-   * @param token - The token address
-   * @param initialAdmins - The initial admin addresses
-   * @param threshold - The signature threshold
-   * @returns The base64-encoded XDR envelope
+   * Creates a pool. With a keypair, signs and submits; otherwise returns XDR.
    */
-  createPool(admin: string, token: string, initialAdmins: string[], threshold: number): string {
+  async createPool(
+    keypair: Keypair,
+    admin: string,
+    token: string,
+    initialAdmins: string[],
+    threshold: number
+  ): Promise<SubmitResult>;
+  createPool(admin: string, token: string, initialAdmins: string[], threshold: number): string;
+  createPool(
+    keypairOrAdmin: Keypair | string,
+    adminOrToken: string,
+    tokenOrAdmins: string | string[],
+    adminsOrThreshold: string[] | number,
+    threshold?: number
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrAdmin)) {
+      const xdrEnv = this.buildTx(
+        "create_pool",
+        scvAddress(adminOrToken),
+        scvString(tokenOrAdmins as string),
+        nativeToScVal(
+          (adminsOrThreshold as string[]).map((a) => scvAddress(a)),
+          { type: "vec" }
+        ),
+        scvU64(threshold!)
+      );
+      return this.submitTx(keypairOrAdmin, xdrEnv);
+    }
     return this.buildTx(
       "create_pool",
-      scvAddress(admin),
-      scvString(token),
+      scvAddress(keypairOrAdmin as string),
+      scvString(adminOrToken),
       nativeToScVal(
-        initialAdmins.map((a) => scvAddress(a)),
-        {
-          type: "vec",
-        }
+        (tokenOrAdmins as string[]).map((a) => scvAddress(a)),
+        { type: "vec" }
       ),
-      scvU64(threshold)
+      scvU64(adminsOrThreshold as number)
     );
   }
 
   /**
-   * Builds an XDR envelope for depositing into a pool
-   * @param depositor - The depositor's Stellar address
-   * @param poolId - The pool ID
-   * @param token - The token address
-   * @param amount - The deposit amount
-   * @returns The base64-encoded XDR envelope
+   * Deposits into a pool. With a keypair, signs and submits; otherwise returns XDR.
    */
-  deposit(depositor: string, poolId: string, token: string, amount: number | bigint): string {
+  async deposit(
+    keypair: Keypair,
+    depositor: string,
+    poolId: string,
+    token: string,
+    amount: number | bigint
+  ): Promise<SubmitResult>;
+  deposit(depositor: string, poolId: string, token: string, amount: number | bigint): string;
+  deposit(
+    keypairOrDepositor: Keypair | string,
+    depositorOrPoolId: string,
+    poolIdOrToken: string,
+    tokenOrAmount: string | number | bigint,
+    amount?: number | bigint
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrDepositor)) {
+      const xdrEnv = this.buildTx(
+        "deposit",
+        scvAddress(depositorOrPoolId),
+        scvString(poolIdOrToken),
+        scvString(tokenOrAmount as string),
+        scvI128(amount!)
+      );
+      return this.submitTx(keypairOrDepositor, xdrEnv);
+    }
     return this.buildTx(
       "deposit",
-      scvAddress(depositor),
-      scvString(poolId),
-      scvString(token),
-      scvI128(amount)
+      scvAddress(keypairOrDepositor as string),
+      scvString(depositorOrPoolId),
+      scvString(poolIdOrToken),
+      scvI128(tokenOrAmount as number | bigint)
     );
   }
 
   /**
-   * Builds an XDR envelope for withdrawing from a pool
-   * @param signers - The signers' addresses
-   * @param poolId - The pool ID
-   * @param amount - The withdrawal amount
-   * @param recipient - The recipient address
-   * @returns The base64-encoded XDR envelope
+   * Withdraws from a pool. With a keypair, signs and submits; otherwise returns XDR.
    */
-  withdraw(signers: string[], poolId: string, amount: number | bigint, recipient: string): string {
+  async withdraw(
+    keypair: Keypair,
+    signers: string[],
+    poolId: string,
+    amount: number | bigint,
+    recipient: string
+  ): Promise<SubmitResult>;
+  withdraw(signers: string[], poolId: string, amount: number | bigint, recipient: string): string;
+  withdraw(
+    keypairOrSigners: Keypair | string[],
+    signersOrPoolId: string[] | string,
+    poolIdOrAmount: string | number | bigint,
+    amountOrRecipient: number | bigint | string,
+    recipient?: string
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrSigners)) {
+      const xdrEnv = this.buildTx(
+        "withdraw",
+        nativeToScVal(
+          (signersOrPoolId as string[]).map((s) => scvAddress(s)),
+          { type: "vec" }
+        ),
+        scvString(poolIdOrAmount as string),
+        scvI128(amountOrRecipient as number | bigint),
+        scvAddress(recipient!)
+      );
+      return this.submitTx(keypairOrSigners, xdrEnv);
+    }
     return this.buildTx(
       "withdraw",
       nativeToScVal(
-        signers.map((s) => scvAddress(s)),
+        (keypairOrSigners as string[]).map((s) => scvAddress(s)),
         { type: "vec" }
       ),
-      scvString(poolId),
-      scvI128(amount),
-      scvAddress(recipient)
+      scvString(signersOrPoolId as string),
+      scvI128(poolIdOrAmount as number | bigint),
+      scvAddress(amountOrRecipient as string)
     );
   }
 
   /**
-   * Builds an XDR envelope for setting a user profile
-   * @param user - The user's Stellar address
-   * @param username - The desired username (3–32 alphanumeric or _ characters)
-   * @param creatorToken - The creator token contract address
-   * @returns The base64-encoded XDR envelope
+   * Sets a user profile. With a keypair, signs and submits; otherwise returns XDR.
    */
-  setProfile(user: string, username: string, creatorToken: string): string {
+  async setProfile(
+    keypair: Keypair,
+    user: string,
+    params: { user: string; username: string; creator_token: string }
+  ): Promise<SubmitResult>;
+  setProfile(user: string, username: string, creatorToken: string): string;
+  setProfile(
+    keypairOrUser: Keypair | string,
+    userOrUsername: string,
+    paramsOrCreatorToken: { user: string; username: string; creator_token: string } | string
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrUser)) {
+      const p = paramsOrCreatorToken as { user: string; username: string; creator_token: string };
+      const xdrEnv = this.buildTx(
+        "set_profile",
+        scvAddress(p.user),
+        scvString(p.username),
+        scvAddress(p.creator_token)
+      );
+      return this.submitTx(keypairOrUser, xdrEnv);
+    }
     return this.buildTx(
       "set_profile",
-      scvAddress(user),
-      scvString(username),
-      scvAddress(creatorToken)
+      scvAddress(keypairOrUser as string),
+      scvString(userOrUsername),
+      scvAddress(paramsOrCreatorToken as string)
     );
   }
 
   /**
-   * Builds an XDR envelope for blocking a user
-   * @param blocker - The blocker's Stellar address
-   * @param blocked - The address to block
-   * @returns The base64-encoded XDR envelope
+   * Blocks a user. With a keypair, signs and submits; otherwise returns XDR.
    */
-  block(blocker: string, blocked: string): string {
-    return this.buildTx("block", scvAddress(blocker), scvAddress(blocked));
+  async block(keypair: Keypair, blocker: string, blocked: string): Promise<SubmitResult>;
+  block(blocker: string, blocked: string): string;
+  block(
+    keypairOrBlocker: Keypair | string,
+    blockerOrBlocked: string,
+    blocked?: string
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrBlocker)) {
+      const xdrEnv = this.buildTx("block", scvAddress(blockerOrBlocked), scvAddress(blocked!));
+      return this.submitTx(keypairOrBlocker, xdrEnv);
+    }
+    return this.buildTx(
+      "block",
+      scvAddress(keypairOrBlocker as string),
+      scvAddress(blockerOrBlocked)
+    );
   }
 
   /**
-   * Builds an XDR envelope for unblocking a user
-   * @param blocker - The blocker's Stellar address
-   * @param blocked - The address to unblock
-   * @returns The base64-encoded XDR envelope
+   * Unblocks a user. With a keypair, signs and submits; otherwise returns XDR.
    */
-  unblock(blocker: string, blocked: string): string {
-    return this.buildTx("unblock", scvAddress(blocker), scvAddress(blocked));
+  async unblock(keypair: Keypair, blocker: string, blocked: string): Promise<SubmitResult>;
+  unblock(blocker: string, blocked: string): string;
+  unblock(
+    keypairOrBlocker: Keypair | string,
+    blockerOrBlocked: string,
+    blocked?: string
+  ): Promise<SubmitResult> | string {
+    if (isKeypair(keypairOrBlocker)) {
+      const xdrEnv = this.buildTx("unblock", scvAddress(blockerOrBlocked), scvAddress(blocked!));
+      return this.submitTx(keypairOrBlocker, xdrEnv);
+    }
+    return this.buildTx(
+      "unblock",
+      scvAddress(keypairOrBlocker as string),
+      scvAddress(blockerOrBlocked)
+    );
   }
 }


### PR DESCRIPTION
## Summary

Resolves #94 and #93.

### Changes

**`packages/sdk/src/client.ts`**
- Added `submitTx(keypair, xdrEnvelope)` — prepares (simulates + resource fees), signs, submits, and polls until the transaction is confirmed or fails.
- All 12 write methods (`createPost`, `deletePost`, `follow`, `unfollow`, `like`, `unlike`, `tip`, `createPool`, `deposit`, `withdraw`, `setProfile`, `block`, `unblock`) now have two overloads:
  - **With keypair** → signs and submits on-chain, returns `SubmitResult` (`{ txHash }`) or `CreatePostResult` (`{ txHash, postId }`)
  - **Without keypair** → unchanged behavior, returns raw base64-XDR string (backward-compatible)
- Switched keypair detection from `instanceof Keypair` (breaks under jest mocks) to duck-type `isKeypair()` guard (checks for `.sign` method).

**`packages/sdk/src/__tests__/submit.test.ts`** _(new file)_
- Full unit coverage for the sign-and-submit path: `submitTx` (happy path, NOT_FOUND polling, ERROR status, on-chain failure) plus every write-method overload.

### Tests

```
Test Suites: 5 passed, 5 total
Tests:       84 passed, 84 total
```

Closes #94
Closes #93