### PR TITLE
docs(sdk): add KovaraClient examples and error handling docs

### DIFF
--- a/docs/sdk/error-handling.md
+++ b/docs/sdk/error-handling.md
@@ -1,0 +1,227 @@
+# SDK Error Handling
+
+All errors thrown by the Kovara SDK are instances of `KovaraError` or one of its typed subclasses. Every subclass can be caught individually with `instanceof`, making it straightforward to show the right feedback for each failure mode.
+
+---
+
+## Error Hierarchy
+
+```
+KovaraError
+├── NotFoundError           – resource does not exist on-chain
+├── UnauthorizedError       – caller lacks permission
+├── InsufficientBalanceError – not enough XLM or token allowance
+├── CooldownError           – tipping cooldown has not expired
+└── InvalidInputError       – parameter validation failed
+```
+
+`InvalidManifestError` (mini-apps only) also extends `KovaraError`.
+
+---
+
+## Error Classes
+
+### `KovaraError`
+
+Base class. Thrown when no specific subclass matches.
+
+| Property        | Type                   | Description                                       |
+| --------------- | ---------------------- | ------------------------------------------------- |
+| `message`       | `string`               | Human-readable description                        |
+| `name`          | `string`               | Always the subclass name (e.g. `"NotFoundError"`) |
+| `originalError` | `unknown \| undefined` | The raw error from the RPC layer                  |
+
+```ts
+import { KovaraError } from "@kovara/sdk";
+
+try {
+  await client.getPost(999);
+} catch (err) {
+  if (err instanceof KovaraError) {
+    console.error(err.name, err.message);
+  }
+}
+```
+
+---
+
+### `NotFoundError`
+
+Thrown when a post, pool, or profile does not exist on-chain.
+
+**Triggers:** contract error messages matching `not found` or `does not exist`.
+
+```ts
+import { NotFoundError } from "@kovara/sdk";
+
+const post = await client.getPost(999).catch((err) => {
+  if (err instanceof NotFoundError) {
+    return null; // treat as missing
+  }
+  throw err;
+});
+```
+
+---
+
+### `UnauthorizedError`
+
+Thrown when the caller is not permitted to perform the operation.
+
+**Common causes:**
+
+- Editing or deleting another user's post (`only author`)
+- Calling a pool admin function without admin role (`only admin` / `not admin`)
+- Interacting with a user who has blocked you (`blocked`)
+
+```ts
+import { UnauthorizedError } from "@kovara/sdk";
+
+try {
+  const xdr = client.deletePost(otherUserAddress, postId);
+  // ... sign and submit
+} catch (err) {
+  if (err instanceof UnauthorizedError) {
+    alert("You are not allowed to delete this post.");
+  }
+}
+```
+
+---
+
+### `InsufficientBalanceError`
+
+Thrown when the account has insufficient XLM or has not approved enough token allowance for the operation.
+
+**Triggers:** messages matching `allowance`, `insufficient allowance`, `balance`, `low balance`, or `insufficient balance`.
+
+```ts
+import { InsufficientBalanceError } from "@kovara/sdk";
+
+try {
+  const xdr = client.tip(senderAddress, postId, 50_000_000n);
+  // ... sign and submit
+} catch (err) {
+  if (err instanceof InsufficientBalanceError) {
+    alert("Not enough balance. Top up your wallet and try again.");
+  }
+}
+```
+
+---
+
+### `CooldownError`
+
+Thrown when a tip is attempted before the per-sender cooldown window has elapsed for a given post.
+
+**Trigger:** contract error message matching `cooldown`.
+
+```ts
+import { CooldownError } from "@kovara/sdk";
+
+try {
+  const xdr = client.tip(senderAddress, postId, amount);
+  // ... sign and submit
+} catch (err) {
+  if (err instanceof CooldownError) {
+    alert("You already tipped this post recently. Please wait before tipping again.");
+  }
+}
+```
+
+---
+
+### `InvalidInputError`
+
+Thrown when parameters fail pre-flight validation inside the contract.
+
+**Common causes:**
+
+- Username is shorter than 3 or longer than 32 characters, or contains invalid characters
+- Post content exceeds 500 characters
+- Tip amount is zero or negative
+- Pool threshold exceeds the number of admins
+
+**Triggers:** messages matching `invalid`, `too long`, `must be positive`, or `cannot exceed`.
+
+```ts
+import { InvalidInputError } from "@kovara/sdk";
+
+try {
+  const xdr = client.createPost(address, "");
+  // ... sign and submit
+} catch (err) {
+  if (err instanceof InvalidInputError) {
+    alert(`Input error: ${err.message}`);
+  }
+}
+```
+
+---
+
+### `InvalidManifestError`
+
+Thrown by `validateManifest()` when a mini-app manifest fails JSON schema validation. Only relevant to mini-app developers.
+
+```ts
+import { validateManifest, InvalidManifestError } from "@kovara/sdk";
+
+try {
+  validateManifest(manifestJson);
+} catch (err) {
+  if (err instanceof InvalidManifestError) {
+    console.error("Manifest invalid:", err.message);
+  }
+}
+```
+
+---
+
+## Catching All Errors
+
+For a catch-all handler that still differentiates known errors from unexpected ones:
+
+```ts
+import {
+  KovaraError,
+  NotFoundError,
+  UnauthorizedError,
+  InsufficientBalanceError,
+  CooldownError,
+  InvalidInputError,
+} from "@kovara/sdk";
+
+async function submitPost(address: string, content: string) {
+  try {
+    const xdr = client.createPost(address, content);
+    // ... sign and submit
+  } catch (err) {
+    if (err instanceof NotFoundError) return showError("Resource not found.");
+    if (err instanceof UnauthorizedError) return showError("Permission denied.");
+    if (err instanceof InsufficientBalanceError) return showError("Insufficient balance.");
+    if (err instanceof CooldownError) return showError("Cooldown active. Try later.");
+    if (err instanceof InvalidInputError) return showError(err.message);
+    if (err instanceof KovaraError) return showError("SDK error: " + err.message);
+    throw err; // re-throw unexpected non-SDK errors
+  }
+}
+```
+
+---
+
+## How Errors Are Mapped
+
+The SDK's internal `mapError(err)` function converts raw Soroban RPC simulation error strings into typed subclasses using regex matching on the error message. The mapping table is:
+
+| Pattern (case-insensitive)                                    | Mapped to                  |
+| ------------------------------------------------------------- | -------------------------- |
+| `allowance` / `insufficient allowance`                        | `InsufficientBalanceError` |
+| `balance` / `low balance` / `insufficient balance`            | `InsufficientBalanceError` |
+| `unauthorized` / `not admin` / `only admin` / `only author`   | `UnauthorizedError`        |
+| `blocked`                                                     | `UnauthorizedError`        |
+| `not found` / `does not exist`                                | `NotFoundError`            |
+| `cooldown`                                                    | `CooldownError`            |
+| `invalid` / `too long` / `must be positive` / `cannot exceed` | `InvalidInputError`        |
+| _(anything else)_                                             | `KovaraError`              |
+
+You can inspect the `originalError` property on any caught error to access the raw RPC response for debugging.

--- a/docs/sdk/examples.md
+++ b/docs/sdk/examples.md
@@ -1,0 +1,181 @@
+# KovaraClient Usage Examples
+
+Practical, typed examples for the most common SDK operations: creating posts, sending tips, and liking posts.
+
+All write methods return a **base64-encoded XDR envelope** you sign and submit via your wallet or keypair. Read methods return fully-typed objects directly.
+
+---
+
+## Setup
+
+```ts
+import { KovaraClient } from "@kovara/sdk";
+
+const client = new KovaraClient({
+  contractId: "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  // defaults to Testnet passphrase; set for Mainnet:
+  // networkPassphrase: "Public Global Stellar Network ; September 2015",
+});
+```
+
+---
+
+## Post Creation
+
+### Build and submit a post
+
+`createPost` returns an XDR string. Sign it with your keypair or wallet, then submit to Stellar.
+
+```ts
+import { KovaraClient } from "@kovara/sdk";
+import { Keypair, rpc, TransactionBuilder } from "@stellar/stellar-sdk";
+
+const client = new KovaraClient({
+  contractId: "C...",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+});
+const keypair = Keypair.fromSecret("S...");
+const server = new rpc.Server("https://soroban-testnet.stellar.org");
+
+// 1. Build the unsigned XDR envelope
+const xdrEnvelope: string = client.createPost(
+  keypair.publicKey(), // author address
+  "Hello Kovara! 🌍" // post content (max 500 chars)
+);
+
+// 2. Sign
+const tx = TransactionBuilder.fromXDR(xdrEnvelope, "Test SDF Network ; September 2015");
+tx.sign(keypair);
+
+// 3. Submit
+const result = await server.sendTransaction(tx);
+console.log("Post submitted. Hash:", result.hash);
+```
+
+### Read back the post
+
+```ts
+import { Post } from "@kovara/sdk";
+
+const post: Post | null = await client.getPost(1);
+if (post) {
+  console.log(`@${post.username}: ${post.content}`);
+  console.log(`Likes: ${post.like_count}  Tips: ${post.tip_total}`);
+}
+```
+
+**`Post` type:**
+
+```ts
+interface Post {
+  id: number;
+  author: string; // Stellar address
+  username: string;
+  content: string;
+  tip_total: number;
+  timestamp: number; // Unix seconds
+  like_count: number;
+}
+```
+
+---
+
+## Tips
+
+### Send a tip
+
+Tips are denominated in the contract's native stroops (1 XLM = 10,000,000 stroops). `amount` accepts `number | bigint`.
+
+```ts
+const TIP_AMOUNT = 5_000_000n; // 0.5 XLM in stroops
+
+const xdrEnvelope: string = client.tip(
+  keypair.publicKey(), // sender address
+  42, // postId
+  TIP_AMOUNT
+);
+
+const tx = TransactionBuilder.fromXDR(xdrEnvelope, "Test SDF Network ; September 2015");
+tx.sign(keypair);
+const result = await server.sendTransaction(tx);
+console.log("Tip sent. Hash:", result.hash);
+```
+
+> **Cooldown:** The contract enforces a per-sender cooldown between tips to the same post. If you tip before the window expires, the SDK throws `CooldownError`. See [Error Handling](./error-handling.md).
+
+### Check tip total on a post
+
+```ts
+const post = await client.getPost(42);
+console.log("Total tips received:", post?.tip_total);
+```
+
+---
+
+## Likes
+
+### Like a post
+
+```ts
+const xdrEnvelope: string = client.like(
+  keypair.publicKey(), // liker address
+  42 // postId
+);
+
+const tx = TransactionBuilder.fromXDR(xdrEnvelope, "Test SDF Network ; September 2015");
+tx.sign(keypair);
+await server.sendTransaction(tx);
+```
+
+### Unlike a post
+
+```ts
+const xdrEnvelope: string = client.unlike(keypair.publicKey(), 42);
+const tx = TransactionBuilder.fromXDR(xdrEnvelope, "Test SDF Network ; September 2015");
+tx.sign(keypair);
+await server.sendTransaction(tx);
+```
+
+### Check whether an address has liked a post
+
+```ts
+const liked: boolean = await client.hasLiked(keypair.publicKey(), 42);
+console.log("Has liked:", liked);
+```
+
+### Get total like count
+
+```ts
+const count: number = await client.getLikeCount(42);
+console.log("Like count:", count);
+```
+
+---
+
+## Browser / Freighter Wallet
+
+In a browser context replace `Keypair.sign` with Freighter's `signTransaction`:
+
+```ts
+import freighterApi from "@stellar/freighter-api";
+
+const publicKey = await freighterApi.getPublicKey();
+const xdrEnvelope = client.createPost(publicKey, "Posted from the browser!");
+
+const signedXdr = await freighterApi.signTransaction(xdrEnvelope, {
+  networkPassphrase: "Test SDF Network ; September 2015",
+});
+
+const tx = TransactionBuilder.fromXDR(signedXdr, "Test SDF Network ; September 2015");
+await server.sendTransaction(tx);
+```
+
+---
+
+## Tips & Best Practices
+
+- **Validate content length** before calling `createPost`. The contract rejects content longer than 500 characters and throws `InvalidInputError`.
+- **Use `bigint` for amounts** to avoid floating-point precision issues with large stroop values.
+- **Simulate first** with `server.simulateTransaction(tx)` to catch errors and estimate fees before submitting.
+- **Handle errors by type** — import `NotFoundError`, `CooldownError`, etc. from `@kovara/sdk`. See [Error Handling](./error-handling.md) for the full classification.


### PR DESCRIPTION
## Summary

Adds two new SDK documentation files to `docs/sdk/`.

### docs/sdk/examples.md (closes #95)
- Typed end-to-end examples for post creation, tips, and likes using `KovaraClient`
- Shows the full build → sign → submit flow with `@stellar/stellar-sdk`
- Covers the browser/Freighter wallet pattern
- Best-practice guidance: content validation, bigint amounts, simulate-before-submit

### docs/sdk/error-handling.md (closes #96)
- Full error class hierarchy (`KovaraError` → typed subclasses)
- Per-class documentation with trigger conditions and code samples
- Catch-all handler recipe
- `mapError` trigger-pattern reference table

## Testing
All 67 existing SDK unit tests pass (4 suites: read, write, errors, validateManifest). No source code was changed.