### PR TITLE
Add tip token mismatch tests

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -797,6 +797,14 @@ impl KovaraContract {
             panic!("blocked");
         }
 
+        if let Some(profile) = env
+            .storage()
+            .persistent()
+            .get::<_, Profile>(&StorageKey::Profile(post.author.clone()))
+        {
+            assert!(profile.creator_token == token, "wrong token for tip");
+        }
+
         // Check tip cooldown: one tip per tipper per post per cooldown window.
         let cooldown_key = StorageKey::TipCooldown(post_id, tipper.clone());
         let current_ledger = env.ledger().sequence();
@@ -900,7 +908,10 @@ impl KovaraContract {
         amount: i128,
     ) {
         Self::bump_instance(&env);
-        assert!(amount > 0, "deposit amount must be strictly greater than zero");
+        assert!(
+            amount > 0,
+            "deposit amount must be strictly greater than zero"
+        );
         depositor.require_auth();
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -367,6 +367,55 @@ fn test_tip_fee_split() {
 }
 
 #[test]
+#[should_panic(expected = "wrong token for tip")]
+fn test_tip_rejects_mismatched_creator_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let author = Address::generate(&env);
+    let tipper = Address::generate(&env);
+
+    client.initialize(&admin, &treasury, &250);
+
+    let allowed_token = setup_token(&env, &tipper);
+    let mismatched_token = setup_token(&env, &tipper);
+    client.set_profile(&author, &String::from_str(&env, "alice"), &allowed_token);
+
+    let post_id = client.create_post(&author, &String::from_str(&env, "Creator token test"));
+    client.tip(&tipper, &post_id, &mismatched_token, &1000);
+}
+
+#[test]
+fn test_tip_accepts_matching_creator_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let author = Address::generate(&env);
+    let tipper = Address::generate(&env);
+
+    client.initialize(&admin, &treasury, &250);
+
+    let creator_token = setup_token(&env, &tipper);
+    client.set_profile(&author, &String::from_str(&env, "alice"), &creator_token);
+
+    let post_id = client.create_post(&author, &String::from_str(&env, "Creator token test"));
+    client.tip(&tipper, &post_id, &creator_token, &1000);
+
+    let post = client.get_post(&post_id).unwrap();
+    assert_eq!(post.tip_total, 1000);
+}
+
+#[test]
 #[should_panic(expected = "blocked")]
 fn test_tip_blocked_by_author() {
     let env = Env::default();
@@ -2883,4 +2932,3 @@ fn test_pool_deposit_negative_rejected() {
     let other_user = Address::generate(&env);
     client.pool_deposit(&other_user, &pool_id, &token, &-50);
 }
-


### PR DESCRIPTION
closes #77

## Summary
- add regression coverage for mismatched tip tokens
- ensure matching creator tokens still allow tips
- enforce safe failure when the supplied token does not match the author profile