### PR TITLE
fix(#63): Add tests for rejecting zero and negative tip amounts

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -509,6 +509,52 @@ fn test_tip_non_blocked_user() {
 }
 
 #[test]
+#[should_panic(expected = "tip amount must be positive")]
+fn test_tip_zero_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let author = Address::generate(&env);
+    let tipper = Address::generate(&env);
+
+    client.initialize(&admin, &treasury, &250);
+
+    let token = setup_token(&env, &tipper);
+    let post_id = client.create_post(&author, &String::from_str(&env, "Test post"));
+
+    // Attempt to tip with zero amount should panic
+    client.tip(&tipper, &post_id, &token, &0);
+}
+
+#[test]
+#[should_panic(expected = "tip amount must be positive")]
+fn test_tip_negative_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let author = Address::generate(&env);
+    let tipper = Address::generate(&env);
+
+    client.initialize(&admin, &treasury, &250);
+
+    let token = setup_token(&env, &tipper);
+    let post_id = client.create_post(&author, &String::from_str(&env, "Test post"));
+
+    // Attempt to tip with negative amount should panic
+    client.tip(&tipper, &post_id, &token, &-100);
+}
+
+#[test]
 fn test_profile_count() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
The tip() function already validates that amount > 0, but tests for this security requirement were missing. Add two tests:
- test_tip_zero_amount_rejected: Verifies that tipping 0 is rejected
- test_tip_negative_amount_rejected: Verifies that tipping negative amounts is rejected

Both tests expect the panic message 'tip amount must be positive'.

Fixes: #63
Labels: good first issue, bug, contracts, security

## Summary

<!-- What does this PR do and why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Contract change (logic, storage, or API)
- [ ] Documentation update
- [ ] Refactor / chore

## Testing Done

<!-- Describe what you tested and how. -->

- [ ] `cargo test` passes
- [ ] New tests added for changed behaviour
- [ ] Manually verified on Testnet (if applicable)

## Checklist

- [ ] Changes are focused — one concern per PR
- [ ] If a contract function was added or changed, the README API table is updated
- [ ] No unresolved merge conflicts
- [ ] No secrets or private keys committed

## Related Issue

Closes #63
