### PR TITLE
feat(mobile): wire post creation and profile fetch to KovaraClient SDK

### DIFF
--- a/apps/mobile/utils/createPost.ts
+++ b/apps/mobile/utils/createPost.ts
@@ -1,0 +1,37 @@
+import { KovaraClient } from "../../../packages/sdk/src/client";
+
+interface WalletKit {
+  signAndSubmitTransaction?: (opts: { txXdr: string; rpcUrl?: string }) => Promise<{ hash?: string; txHash?: string }>;
+  signTransaction?: (opts: { txXdr: string }) => Promise<{ signedTxXdr: string }>;
+}
+
+export interface CreatePostOptions {
+  contractId: string;
+  rpcUrl: string;
+  author: string;
+  content: string;
+}
+
+export async function createPost(opts: CreatePostOptions): Promise<string> {
+  const { contractId, rpcUrl, author, content } = opts;
+  const client = new KovaraClient({ contractId, rpcUrl });
+  const txXdr = client.createPost(author, content);
+
+  const kit = (globalThis as unknown as { __Kovara_WALLET_KIT__?: WalletKit }).__Kovara_WALLET_KIT__;
+  if (!kit) throw new Error("Wallet not connected");
+
+  if (typeof kit.signAndSubmitTransaction === "function") {
+    const res = await kit.signAndSubmitTransaction({ txXdr, rpcUrl });
+    return res?.hash ?? res?.txHash ?? "";
+  }
+
+  if (typeof kit.signTransaction === "function") {
+    const signed = await kit.signTransaction({ txXdr });
+    const { rpc } = await import("@stellar/stellar-sdk");
+    const server = new rpc.Server(rpcUrl);
+    const res = await server.submitTransaction(signed.signedTxXdr);
+    return res?.hash ?? "";
+  }
+
+  throw new Error("Wallet signing not available");
+}

--- a/apps/mobile/utils/fetchProfile.ts
+++ b/apps/mobile/utils/fetchProfile.ts
@@ -1,0 +1,26 @@
+import { KovaraClient } from "../../../packages/sdk/src/client";
+
+export interface ProfileData {
+  address: string;
+  username: string | null;
+  bio: string | null;
+}
+
+export async function fetchProfile(
+  address: string,
+  contractId: string,
+  rpcUrl: string
+): Promise<ProfileData | null> {
+  if (!address) return null;
+
+  const client = new KovaraClient({ contractId, rpcUrl });
+  const raw = await client.getProfile(address);
+
+  if (!raw) return null;
+
+  return {
+    address,
+    username: raw.username ?? null,
+    bio: (raw.bio as string) ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

- Wires `submitCreatePost` to the real `KovaraClient.createPost` SDK method
- Replaces placeholder profile state with a real `client.getProfile` contract call

## Changes

- `apps/mobile/utils/createPost.ts` - typed helper that builds the tx XDR via `KovaraClient` and submits it through the injected wallet kit
- `apps/mobile/utils/fetchProfile.ts` - fetches `username` and `bio` from the contract and normalises nulls

closes #127
closes #126