### PR TITLE
feat(mobile): add typed Freighter wallet adapter and user-facing contract error mapping

### DIFF
--- a/apps/mobile/utils/contractErrors.ts
+++ b/apps/mobile/utils/contractErrors.ts
@@ -1,0 +1,31 @@
+export type ContractErrorCode =
+  | "UNAUTHORIZED"
+  | "INVALID_STATE"
+  | "NOT_FOUND"
+  | "ALREADY_EXISTS"
+  | "UNKNOWN";
+
+const MESSAGES: Record<ContractErrorCode, string> = {
+  UNAUTHORIZED: "You are not authorized to perform this action.",
+  INVALID_STATE: "This action is not allowed in the current state.",
+  NOT_FOUND: "The requested resource was not found.",
+  ALREADY_EXISTS: "This item already exists.",
+  UNKNOWN: "An unexpected error occurred. Please try again.",
+};
+
+export function mapContractError(error: unknown): string {
+  if (!(error instanceof Error)) return MESSAGES.UNKNOWN;
+
+  const msg = error.message.toLowerCase();
+
+  if (msg.includes("unauthorized") || msg.includes("auth"))
+    return MESSAGES.UNAUTHORIZED;
+  if (msg.includes("invalid") || msg.includes("state"))
+    return MESSAGES.INVALID_STATE;
+  if (msg.includes("not found") || msg.includes("notfound"))
+    return MESSAGES.NOT_FOUND;
+  if (msg.includes("already") || msg.includes("exists"))
+    return MESSAGES.ALREADY_EXISTS;
+
+  return MESSAGES.UNKNOWN;
+}

--- a/apps/mobile/utils/walletAdapter.ts
+++ b/apps/mobile/utils/walletAdapter.ts
@@ -1,0 +1,39 @@
+export interface WalletAdapter {
+  getPublicKey(): Promise<string>;
+  isConnected(): Promise<boolean>;
+  signTransaction(txXdr: string): Promise<string>;
+  signAndSubmitTransaction(txXdr: string, rpcUrl: string): Promise<string>;
+  disconnect(): Promise<void>;
+}
+
+export function getFreighterAdapter(): WalletAdapter {
+  return {
+    async getPublicKey() {
+      const { getPublicKey } = await import("@stellar/freighter-api");
+      const res = await getPublicKey();
+      if (res.error) throw new Error(res.error.message);
+      return res.publicKey;
+    },
+    async isConnected() {
+      const { isConnected } = await import("@stellar/freighter-api");
+      const res = await isConnected();
+      return res.isConnected;
+    },
+    async signTransaction(txXdr: string) {
+      const { signTransaction } = await import("@stellar/freighter-api");
+      const res = await signTransaction(txXdr);
+      if (res.error) throw new Error(res.error.message);
+      return res.signedTxXdr;
+    },
+    async signAndSubmitTransaction(txXdr: string, rpcUrl: string) {
+      const signed = await this.signTransaction(txXdr);
+      const { rpc } = await import("@stellar/stellar-sdk");
+      const server = new rpc.Server(rpcUrl);
+      const res = await server.submitTransaction(signed);
+      return res?.hash ?? "";
+    },
+    async disconnect() {
+      // Freighter does not expose a disconnect API; caller clears local state
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a fully-typed Freighter wallet adapter with no `any` casts
- Adds user-facing error mapping so contract failures (unauthorized, invalid state, not found) surface readable messages

## Changes

- `apps/mobile/utils/walletAdapter.ts` - `WalletAdapter` interface + `getFreighterAdapter()` implementation with typed Freighter API imports
- `apps/mobile/utils/contractErrors.ts` - `mapContractError` maps raw error messages to human-readable strings

closes #124
closes #120