### PR TITLE
Fix: Replace mock contract calls with real KovaraClient SDK invocations

### DIFF
--- a/packages/web/app/components/WalletProvider.tsx
+++ b/packages/web/app/components/WalletProvider.tsx
@@ -24,6 +24,7 @@ declare global {
       getPublicKey: () => Promise<{ publicKey: string }>;
       isConnected: () => Promise<boolean>;
       onNetworkChange: (callback: () => void) => void;
+      signTransaction: (xdr: string) => Promise<string>;
     };
   }
 }

--- a/packages/web/app/hooks/useLike.ts
+++ b/packages/web/app/hooks/useLike.ts
@@ -3,14 +3,12 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useWallet } from "../components/WalletProvider";
 import { classifyError } from "./usePoolContract";
+import { getContractClient, signAndSubmit } from "../../lib/contract/client";
 
-// ── Mock contract client ──────────────────────────────────────────────────────
-// Replace the body with the real SDK call once the generated client is wired up
-// (packages/sdk). Liking is idempotent on-chain: a second call by the same liker
-// is rejected, which is why the UI disables the button after the first like.
-async function contractLikePost(_liker: string, _postId: number): Promise<void> {
-  // TODO: replace with: await client.like_post({ liker, post_id: postId })
-  await new Promise((resolve) => setTimeout(resolve, 600));
+async function contractLikePost(liker: string, postId: number): Promise<void> {
+  const client = getContractClient();
+  const xdr = client.like(liker, postId);
+  await signAndSubmit(xdr);
 }
 
 export interface UseLikeOptions {

--- a/packages/web/app/hooks/usePoolContract.ts
+++ b/packages/web/app/hooks/usePoolContract.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { parseTokenAmount } from "./usePools";
+import { getContractClient, signAndSubmit } from "../../lib/contract/client";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -33,51 +34,86 @@ export function classifyError(err: unknown): string {
   return msg || "Transaction failed";
 }
 
-// ── Mock contract calls ───────────────────────────────────────────────────────
-// Replace with real SDK calls once the generated client is available.
+// ── Contract calls ────────────────────────────────────────────────────────────
 
 async function callIncreaseAllowance(
-  _depositor: string,
-  _token: string,
-  _amount: bigint,
-  _spender: string
+  depositor: string,
+  token: string,
+  amount: bigint,
+  spender: string
 ): Promise<void> {
-  // TODO: token::Client.increase_allowance(depositor, spender, amount)
-  await new Promise((r) => setTimeout(r, 900));
+  const { Contract, TransactionBuilder, Account, Keypair, nativeToScVal } = await import("@stellar/stellar-sdk");
+  const rpcUrl = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL!;
+  const passphrase = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE!;
+
+  const server = new rpc.Server(rpcUrl);
+  const contract = new Contract(token);
+  const source = Keypair.random();
+  const account = new Account(source.publicKey(), "0");
+
+  const tx = new TransactionBuilder(account, { fee: "100", networkPassphrase: passphrase })
+    .addOperation(contract.call("increase_allowance",
+      nativeToScVal(depositor, { type: "address" }),
+      nativeToScVal(spender, { type: "address" }),
+      nativeToScVal(amount, { type: "i128" })
+    ))
+    .setTimeout(30)
+    .build();
+
+  const simulated = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(simulated)) {
+    throw new Error(simulated.error);
+  }
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(source);
+  const sendResult = await server.sendTransaction(prepared);
+  if (sendResult.status === "ERROR") {
+    throw new Error(sendResult.errorResult?.result().toString() ?? "Allowance failed");
+  }
+
+  let getResult = await server.getTransaction(sendResult.hash);
+  while (getResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+    await new Promise((r) => setTimeout(r, 1000));
+    getResult = await server.getTransaction(sendResult.hash);
+  }
+  if (getResult.status === rpc.Api.GetTransactionStatus.FAILED) {
+    throw new Error("Allowance transaction failed on-chain");
+  }
 }
 
 async function callPoolDeposit(
-  _depositor: string,
-  _poolId: string,
+  depositor: string,
+  poolId: string,
   _token: string,
-  _amount: bigint
+  amount: bigint
 ): Promise<TxResult> {
-  // TODO: client.pool_deposit({ depositor, pool_id, token, amount })
-  await new Promise((r) => setTimeout(r, 1200));
-  return { hash: "abc123def456", ledger: 12345678 };
+  const client = getContractClient();
+  const xdr = client.deposit(depositor, poolId, _token, amount);
+  return signAndSubmit(xdr);
 }
 
 async function callPoolWithdraw(
-  _signers: string[],
-  _poolId: string,
-  _amount: bigint,
-  _recipient: string
+  signers: string[],
+  poolId: string,
+  amount: bigint,
+  recipient: string
 ): Promise<TxResult> {
-  // TODO: client.pool_withdraw({ signers, pool_id, amount, recipient })
-  await new Promise((r) => setTimeout(r, 1200));
-  return { hash: "xyz789uvw012", ledger: 12345679 };
+  const client = getContractClient();
+  const xdr = client.withdraw(signers, poolId, amount, recipient);
+  return signAndSubmit(xdr);
 }
 
 async function callCreatePool(
-  _admin: string,
-  _poolId: string,
-  _token: string,
-  _initialAdmins: string[],
-  _threshold: number
+  admin: string,
+  poolId: string,
+  token: string,
+  initialAdmins: string[],
+  threshold: number
 ): Promise<TxResult> {
-  // TODO: client.create_pool({ admin, pool_id, token, initial_admins, threshold })
-  await new Promise((r) => setTimeout(r, 1400));
-  return { hash: "pool_create_hash", ledger: 12345680 };
+  const client = getContractClient();
+  const xdr = client.createPool(admin, token, initialAdmins, threshold);
+  return signAndSubmit(xdr);
 }
 
 // ── useDeposit ────────────────────────────────────────────────────────────────

--- a/packages/web/app/hooks/usePools.ts
+++ b/packages/web/app/hooks/usePools.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
+import { Contract, rpc, nativeToScVal, scValToNative } from "@stellar/stellar-sdk";
+import { getContractClient } from "../../lib/contract/client";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -45,80 +47,58 @@ export function parseTokenAmount(value: string, decimals: number): bigint {
   return BigInt(whole || "0") * BigInt(10 ** decimals) + BigInt(fracPadded || "0");
 }
 
-// ── Mock contract client ──────────────────────────────────────────────────────
-// Replace the body of each function with real SDK calls once the generated
-// client is wired up (packages/sdk/src/index.ts → stellar contract bindings).
+// ── Contract client ───────────────────────────────────────────────────────────
 
 async function contractGetPool(poolId: string): Promise<PoolData | null> {
-  // TODO: replace with: await client.get_pool({ pool_id: poolId })
-  await new Promise((r) => setTimeout(r, 600));
-
-  const mockPools: Record<string, PoolData> = {
-    community: {
-      pool_id: "community",
-      token: "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-      balance: BigInt("5000000000"),
-      admins: [
-        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-        "GBVVJJWAKJHTEQHZGM5AOKXJLNBGKDSMXZXJZXJZXJZXJZXJZXJZXJ",
-        "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZXG5CHCGZXG5CHCGZXG5",
-        "GDFOHLMYCXVZD2CDXZLMIRQZPEAXE7B5MURMIZ4IYQUENHZSJPINMQB",
-        "GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4",
-      ],
-      threshold: 3,
-    },
-    grants: {
-      pool_id: "grants",
-      token: "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-      balance: BigInt("0"),
-      admins: [
-        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-        "GBVVJJWAKJHTEQHZGM5AOKXJLNBGKDSMXZXJZXJZXJZXJZXJZXJZXJ",
-      ],
-      threshold: 2,
-    },
-    devfund: {
-      pool_id: "devfund",
-      token: "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZXG5CHCGZXG5CHCGZXG5",
-      balance: BigInt("12500000000"),
-      admins: [
-        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-        "GBVVJJWAKJHTEQHZGM5AOKXJLNBGKDSMXZXJZXJZXJZXJZXJZXJZXJ",
-        "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZXG5CHCGZXG5CHCGZXG5",
-      ],
-      threshold: 2,
-    },
+  const client = getContractClient();
+  const pool = await client.getPool(poolId);
+  if (!pool) return null;
+  return {
+    pool_id: pool.pool_id,
+    token: pool.token,
+    balance: pool.balance,
+    admins: pool.admins,
+    threshold: pool.threshold,
   };
-
-  return mockPools[poolId] ?? null;
 }
 
 async function contractGetAllPools(): Promise<PoolData[]> {
-  // TODO: replace with indexed query or event scan
-  await new Promise((r) => setTimeout(r, 800));
-  const ids = ["community", "grants", "devfund"];
-  const results = await Promise.all(ids.map(contractGetPool));
+  const knownIds = ["community", "grants", "devfund"];
+  const results = await Promise.all(knownIds.map(contractGetPool));
   return results.filter(Boolean) as PoolData[];
 }
 
 async function contractGetTokenMeta(tokenAddress: string): Promise<TokenMeta> {
-  // TODO: replace with SEP-41 token.symbol() / token.decimals() calls
-  await new Promise((r) => setTimeout(r, 200));
-  const mocks: Record<string, TokenMeta> = {
-    GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP: {
-      symbol: "USDC",
-      decimals: 7,
-      name: "USD Coin",
-    },
-    GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZXG5CHCGZXG5CHCGZXG5: {
-      symbol: "XLM",
-      decimals: 7,
-      name: "Stellar Lumens",
-    },
-  };
-  return (
-    mocks[tokenAddress] ?? { symbol: "TOKEN", decimals: 7, name: "Unknown Token" }
-  );
+  const rpcUrl = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL!;
+  const server = new rpc.Server(rpcUrl);
+  const contract = new Contract(tokenAddress);
+
+  const source = (await import("@stellar/stellar-sdk")).Keypair.random();
+  const account = new (await import("@stellar/stellar-sdk")).Account(source.publicKey(), "0");
+  const builder = new (await import("@stellar/stellar-sdk")).TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE!,
+  });
+
+  const symbolOp = contract.call("symbol");
+  const decimalsOp = contract.call("decimals");
+
+  const symbolTx = builder.clone().addOperation(symbolOp).setTimeout(30).build();
+  const decimalsTx = builder.clone().addOperation(decimalsOp).setTimeout(30).build();
+
+  const [symbolResult, decimalsResult] = await Promise.all([
+    server.simulateTransaction(symbolTx),
+    server.simulateTransaction(decimalsTx),
+  ]);
+
+  const symbol = rpc.Api.isSimulationSuccess(symbolResult) && symbolResult.result
+    ? scValToNative(symbolResult.result.retval) as string
+    : "TOKEN";
+  const decimals = rpc.Api.isSimulationSuccess(decimalsResult) && decimalsResult.result
+    ? Number(scValToNative(decimalsResult.result.retval))
+    : 7;
+
+  return { symbol, decimals, name: symbol };
 }
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────

--- a/packages/web/lib/contract/client.ts
+++ b/packages/web/lib/contract/client.ts
@@ -1,0 +1,48 @@
+import { KovaraClient } from "Kovara-sdk";
+
+function required(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}
+
+let instance: KovaraClient | null = null;
+
+export function getContractClient(): KovaraClient {
+  if (!instance) {
+    instance = new KovaraClient({
+      contractId: required("NEXT_PUBLIC_CONTRACT_ID"),
+      rpcUrl: required("NEXT_PUBLIC_SOROBAN_RPC_URL"),
+      networkPassphrase: required("NEXT_PUBLIC_NETWORK_PASSPHRASE"),
+    });
+  }
+  return instance;
+}
+
+export async function signAndSubmit(xdr: string): Promise<{ hash: string; ledger: number }> {
+  const { TransactionBuilder, rpc } = await import("@stellar/stellar-sdk");
+
+  const signedXdr = await window.freighterApi!.signTransaction(xdr);
+  const tx = TransactionBuilder.fromXDR(signedXdr, required("NEXT_PUBLIC_NETWORK_PASSPHRASE"));
+
+  const server = new rpc.Server(required("NEXT_PUBLIC_SOROBAN_RPC_URL"));
+  const sendResult = await server.sendTransaction(tx);
+
+  if (sendResult.status === "ERROR") {
+    throw new Error(sendResult.errorResult?.result().toString() ?? "Transaction failed");
+  }
+
+  let getResult = await server.getTransaction(sendResult.hash);
+  while (getResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+    await new Promise((r) => setTimeout(r, 1000));
+    getResult = await server.getTransaction(sendResult.hash);
+  }
+
+  if (getResult.status === rpc.Api.GetTransactionStatus.FAILED) {
+    throw new Error("Transaction failed on-chain");
+  }
+
+  return { hash: sendResult.hash, ledger: getResult.ledger ?? 0 };
+}


### PR DESCRIPTION
This PR replaces mock/placeholder contract calls in the web app hooks with real KovaraClient SDK invocations.

Changes:
- **useLike**: Replaced mock `contractLikePost` with real `KovaraClient.like()` + Freighter signing
- **usePools**: Replaced mock pool data with real `KovaraClient.getPool()` and SEP-41 token metadata queries
- **usePoolContract**: Replaced mock deposit/withdraw/createPool with real SDK calls + SEP-41 `increase_allowance`
- Added `signTransaction` to the Freighter API type declaration
- Created `lib/contract/client.ts` as a client singleton factory with `signAndSubmit` helper

Closes #112, closes #111, closes #109