### PR TITLE
fix: resolve issues #83, #84, #135, #136

### DIFF
--- a/apps/mobile/app/connect.tsx
+++ b/apps/mobile/app/connect.tsx
@@ -15,7 +15,8 @@ export default function ConnectScreen() {
   const router = useRouter();
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const { address, connected, disconnect, connect, error, state, wallet } = useWallet();
+  const { address, connected, disconnect, connect, error, state, wallet, availability } =
+    useWallet();
 
   const handleConnect = async (provider: WalletProviderKind) => {
     await connect(provider);
@@ -24,6 +25,8 @@ export default function ConnectScreen() {
   const handleDisconnect = async () => {
     await disconnect();
   };
+
+  const hasAnyWallet = availability.freighter || availability.walletconnect;
 
   return (
     <View style={styles.container}>
@@ -58,21 +61,53 @@ export default function ConnectScreen() {
           </View>
         ) : (
           <View style={styles.buttonStack}>
-            <WalletButton
-              label="Connect Freighter"
-              accessibilityLabel="Connect with Freighter wallet"
-              onPress={() => handleConnect("freighter")}
-              provider="freighter"
-              state={state}
-            />
-            <WalletButton
-              label="Connect WalletConnect"
-              accessibilityLabel="Connect with WalletConnect wallet"
-              onPress={() => handleConnect("walletconnect")}
-              provider="walletconnect"
-              state={state}
-              variant="secondary"
-            />
+            {availability.freighter ? (
+              <WalletButton
+                label="Connect Freighter"
+                accessibilityLabel="Connect with Freighter wallet"
+                onPress={() => handleConnect("freighter")}
+                provider="freighter"
+                state={state}
+              />
+            ) : (
+              <View style={styles.unavailableRow}>
+                <Text style={styles.unavailableText}>
+                  ⚠️ Freighter is not detected — install it for the best desktop experience.
+                </Text>
+              </View>
+            )}
+
+            {availability.walletconnect ? (
+              <WalletButton
+                label="Connect WalletConnect"
+                accessibilityLabel="Connect with WalletConnect wallet"
+                onPress={() => handleConnect("walletconnect")}
+                provider="walletconnect"
+                state={state}
+                variant="secondary"
+              />
+            ) : (
+              <View style={styles.unavailableRow}>
+                <Text style={styles.unavailableText}>
+                  ⚠️ WalletConnect is not available — check your project configuration.
+                </Text>
+              </View>
+            )}
+
+            {!hasAnyWallet && state !== "connecting" && (
+              <View style={styles.guidanceBox} accessibilityRole="alert">
+                <Text style={styles.guidanceTitle}>No wallet detected</Text>
+                <Text style={styles.guidanceText}>
+                  To get started, install a Stellar wallet:
+                </Text>
+                <Text style={styles.guidanceBullet}>
+                  • Freighter browser extension (desktop)
+                </Text>
+                <Text style={styles.guidanceBullet}>
+                  • Any WalletConnect-compatible mobile wallet
+                </Text>
+              </View>
+            )}
           </View>
         )}
 
@@ -157,6 +192,45 @@ function createStyles(theme: ReturnType<typeof useTheme>["theme"]) {
     errorText: {
       color: theme.colors.semantic.error,
       fontSize: 13,
+    },
+    unavailableRow: {
+      backgroundColor: theme.colors.surface.surface1,
+      borderColor: theme.colors.surface.border,
+      borderWidth: 1,
+      borderRadius: 8,
+      padding: 10,
+      opacity: 0.8,
+    },
+    unavailableText: {
+      color: theme.colors.text.secondary,
+      fontSize: 12,
+      fontStyle: "italic",
+    },
+    guidanceBox: {
+      marginTop: 16,
+      backgroundColor: theme.colors.surface.surface1,
+      borderColor: theme.colors.brand.secondary,
+      borderWidth: 1,
+      borderRadius: 12,
+      padding: 16,
+    },
+    guidanceTitle: {
+      color: theme.colors.text.primary,
+      fontSize: 15,
+      fontWeight: "700",
+      marginBottom: 8,
+    },
+    guidanceText: {
+      color: theme.colors.text.secondary,
+      fontSize: 13,
+      lineHeight: 20,
+      marginBottom: 8,
+    },
+    guidanceBullet: {
+      color: theme.colors.text.secondary,
+      fontSize: 13,
+      lineHeight: 22,
+      paddingLeft: 4,
     },
   });
 }

--- a/apps/mobile/context/WalletContext.tsx
+++ b/apps/mobile/context/WalletContext.tsx
@@ -25,6 +25,11 @@ export type WalletState = "loading" | "disconnected" | "connecting" | "connected
 
 export type WalletProviderKind = "freighter" | "walletconnect";
 
+export interface WalletAvailability {
+  freighter: boolean;
+  walletconnect: boolean;
+}
+
 export type WalletNetwork = StellarNetworkId;
 
 export interface WalletInfo {
@@ -166,6 +171,8 @@ export interface WalletContextType {
   disconnect: () => Promise<void>;
   refresh: () => Promise<void>;
   setNetwork: (network: WalletNetwork) => void;
+  /** Wallet adapter availability detected at runtime */
+  availability: WalletAvailability;
 }
 
 const WalletContext = createContext<WalletContextType | null>(null);
@@ -181,6 +188,11 @@ export function WalletProvider({ children }: { children: ReactNode }): JSX.Eleme
   });
   const [error, setError] = useState<string | null>(null);
 
+  const [availability, setAvailability] = useState<WalletAvailability>({
+    freighter: false,
+    walletconnect: false,
+  });
+
   const [walletKit, setWalletKit] = useState<WalletConnectLike | null>(
     () => globalThis.__Kovara_WALLET_KIT__ ?? null
   );
@@ -192,6 +204,9 @@ export function WalletProvider({ children }: { children: ReactNode }): JSX.Eleme
       try {
         if (globalThis.__Kovara_WALLET_KIT__) {
           setWalletKit(globalThis.__Kovara_WALLET_KIT__);
+          if (!cancelled) {
+            setAvailability((prev) => ({ ...prev, walletconnect: true }));
+          }
           return;
         }
 
@@ -202,6 +217,7 @@ export function WalletProvider({ children }: { children: ReactNode }): JSX.Eleme
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (globalThis as any).__Kovara_WALLET_KIT__ = adapter;
           setWalletKit(adapter);
+          setAvailability((prev) => ({ ...prev, walletconnect: true }));
         }
       } catch {
         if (!cancelled) {
@@ -215,6 +231,28 @@ export function WalletProvider({ children }: { children: ReactNode }): JSX.Eleme
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  // Detect Freighter availability
+  useEffect(() => {
+    let cancelled = false;
+
+    const detectFreighter = async () => {
+      try {
+        await importFreighterApi();
+        if (!cancelled) {
+          setAvailability((prev) => ({ ...prev, freighter: true }));
+        }
+      } catch {
+        // Freighter not installed — leave as false
+      }
+    };
+
+    detectFreighter();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const importFreighterApi = useCallback(async () => {
@@ -386,6 +424,7 @@ export function WalletProvider({ children }: { children: ReactNode }): JSX.Eleme
     disconnect,
     refresh,
     setNetwork,
+    availability,
   };
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;

--- a/apps/mobile/hooks/useWallet.ts
+++ b/apps/mobile/hooks/useWallet.ts
@@ -8,6 +8,7 @@
  */
 import { useWalletContext } from "../context/WalletContext";
 import type {
+  WalletAvailability,
   WalletInfo,
   WalletNetwork,
   WalletProviderKind,
@@ -35,10 +36,12 @@ export interface UseWalletReturn {
   refresh: () => Promise<void>;
   /** Update the active network preference */
   setNetwork: (network: WalletNetwork) => void;
+  /** Wallet adapter availability detected at runtime */
+  availability: WalletAvailability;
 }
 
 export function useWallet(): UseWalletReturn {
-  const { wallet, network, state, error, connect, disconnect, refresh, setNetwork } =
+  const { wallet, network, state, error, connect, disconnect, refresh, setNetwork, availability } =
     useWalletContext();
 
   return {
@@ -52,6 +55,7 @@ export function useWallet(): UseWalletReturn {
     disconnect,
     refresh,
     setNetwork,
+    availability,
   };
 }
 
@@ -60,6 +64,7 @@ export {
   WalletContext,
   useWalletContext,
   type WalletContextType,
+  type WalletAvailability,
   type WalletInfo,
   type WalletNetwork,
   type WalletProviderKind,

--- a/apps/mobile/hooks/useWallet.tsx
+++ b/apps/mobile/hooks/useWallet.tsx
@@ -9,6 +9,7 @@ export {
   WalletProvider,
   useWalletContext as useWallet,
   WalletContext,
+  type WalletAvailability,
   type WalletContextType,
   type WalletState,
   type WalletInfo,

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -1662,6 +1662,57 @@ fn test_set_fee_non_admin_panics() {
     client.set_fee(&100);
 }
 
+#[test]
+#[should_panic]
+fn test_set_treasury_non_admin_panics() {
+    let env = Env::default();
+    // Don't mock all auths so we can test auth failure
+    let (client, _admin, _) = setup_contract(&env);
+    let new_treasury = Address::generate(&env);
+
+    // Non-admin trying to set treasury should panic due to auth failure
+    client.set_treasury(&new_treasury);
+}
+
+// ── Issue #84: username lookup and uniqueness tests ───────────────────────────
+
+#[test]
+fn test_get_address_by_username_nonexistent() {
+    // Looking up a username that has never been registered must return None.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    assert!(client
+        .get_address_by_username(&String::from_str(&env, "nobody"))
+        .is_none());
+}
+
+#[test]
+fn test_get_address_by_username_after_profile_deleted() {
+    // After a profile is deleted, its username must no longer resolve.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let user = Address::generate(&env);
+    let token = make_token(&env);
+    client.set_profile(&user, &String::from_str(&env, "temp_user"), &token);
+
+    assert!(client
+        .get_address_by_username(&String::from_str(&env, "temp_user"))
+        .is_some());
+
+    client.delete_profile(&user);
+
+    assert!(client
+        .get_address_by_username(&String::from_str(&env, "temp_user"))
+        .is_none());
+}
+
+// ── Fee & Treasury authorization tests (issue #83) ────────────────────────────
+// (test_set_fee_non_admin_panics and test_set_treasury_non_admin_panics above)
+
 // ── Username validation tests (issue #195) ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Resolves issues assigned to DanielCharis1:

### #83 — Add tests for set_fee and set_treasury authorization
- Added `test_set_treasury_non_admin_panics` to verify non-admins cannot update treasury settings
- Complements existing `test_set_fee_non_admin_panics` test

### #84 — Add tests for username lookup and uniqueness
- Added `test_get_address_by_username_nonexistent` — verifies None is returned for never-registered usernames
- Added `test_get_address_by_username_after_profile_deleted` — verifies username resolution is cleared after profile deletion

### #135 — Add mobile UI states for disconnected wallet and onboarding
- Enhanced `ConnectScreen` with wallet-availability-aware UI:
  - Shows per-provider guidance when wallet adapters are not detected
  - Added "No wallet detected" guidance box with installation instructions
  - Conditional rendering based on runtime wallet detection

### #136 — Add mobile device wallet adapter detection and fallback handling
- Added `WalletAvailability` type to `WalletContext`
- Runtime detection of Freighter (via dynamic import) and WalletConnect (via adapter init)
- Exposed `availability` through `useWallet` hook and context
- Connected screen uses detection results to show appropriate UI per provider

## Changes

| File | Changes |
|------|--------|
| `packages/contracts/contracts/linkora-contracts/src/test.rs` | +3 new tests |
| `apps/mobile/context/WalletContext.tsx` | +availability detection |
| `apps/mobile/hooks/useWallet.ts` | +availability in return type |
| `apps/mobile/hooks/useWallet.tsx` | +WalletAvailability re-export |
| `apps/mobile/app/connect.tsx` | +wallet-aware UI with fallback guidance |

Closes #83, closes #84, closes #135, closes #136