### PR TITLE
fix: add post composer validation and Freighter wallet tests (Issues #132, #131)

### DIFF
--- a/apps/mobile/__tests__/walletConnect.test.tsx
+++ b/apps/mobile/__tests__/walletConnect.test.tsx
@@ -62,6 +62,16 @@ jest.mock(
   { virtual: true }
 );
 
+// Mock @stellar/freighter-api
+const mockFreighterApi = {
+  isConnected: jest.fn(),
+  requestAccess: jest.fn(),
+  getPublicKey: jest.fn(),
+  getAddress: jest.fn(),
+};
+
+jest.mock("@stellar/freighter-api", () => mockFreighterApi, { virtual: true });
+
 // Test component to access wallet context
 const TestComponent: React.FC = () => {
   const { state, wallet, connect, disconnect, error } = useWallet();
@@ -84,6 +94,32 @@ const TestComponent: React.FC = () => {
 const TestApp: React.FC = () => (
   <WalletProvider>
     <TestComponent />
+  </WalletProvider>
+);
+
+// Freighter-specific test component with explicit provider button
+const FreighterTestComponent: React.FC = () => {
+  const { state, wallet, connect, disconnect, error } = useWallet();
+
+  return (
+    <View>
+      <Text testID="wallet-state">{state}</Text>
+      <Text testID="wallet-address">{wallet.address || "null"}</Text>
+      <Text testID="wallet-provider">{wallet.provider || "null"}</Text>
+      <Text testID="wallet-error">{error || "null"}</Text>
+      <TouchableOpacity testID="connect-freighter-btn" onPress={() => connect("freighter")}>
+        <Text>Connect Freighter</Text>
+      </TouchableOpacity>
+      <TouchableOpacity testID="disconnect-btn" onPress={disconnect}>
+        <Text>Disconnect</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const FreighterTestApp: React.FC = () => (
+  <WalletProvider>
+    <FreighterTestComponent />
   </WalletProvider>
 );
 
@@ -427,6 +463,261 @@ describe("Wallet Connect Integration Tests", () => {
       expect(getByTestId("wallet-address").children[0]).toBe("null");
 
       // Verify storage is cleared
+      const storedAddress = await secureStorage.getWalletAddress();
+      expect(storedAddress).toBeNull();
+    });
+  });
+});
+
+describe("Freighter Connection Tests", () => {
+  const mockAddress = "GCKFBEIYTKP6RCZNVPH73XL7XFWTEOAO4MKONX7HOILHDVBMW5EVPOPZ";
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mockSecureStore = require("expo-secure-store");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSecureStore.__resetStore();
+
+    // Reset Freighter API mocks
+    mockFreighterApi.isConnected.mockReset();
+    mockFreighterApi.requestAccess.mockReset();
+    mockFreighterApi.getPublicKey.mockReset();
+    mockFreighterApi.getAddress.mockReset();
+
+    // Ensure Wallet Kit mock is present so WalletProvider initializes properly
+    globalThis.__Kovara_WALLET_KIT__ = mockWalletKit;
+  });
+
+  afterEach(() => {
+    delete globalThis.__Kovara_WALLET_KIT__;
+  });
+
+  describe("Successful Connection", () => {
+    it("should connect via Freighter using requestAccess", async () => {
+      // Setup Freighter to be available and return address via requestAccess
+      mockFreighterApi.isConnected.mockResolvedValue(true);
+      mockFreighterApi.requestAccess.mockResolvedValue({ address: mockAddress });
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      // Wait for initial disconnected state
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      // Trigger Freighter connect
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      // Should be connected with Freighter provider
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("connected");
+      });
+
+      expect(getByTestId("wallet-address").children[0]).toBe(mockAddress);
+      expect(getByTestId("wallet-provider").children[0]).toBe("freighter");
+
+      // Verify Freighter API was called
+      expect(mockFreighterApi.isConnected).toHaveBeenCalledTimes(1);
+      expect(mockFreighterApi.requestAccess).toHaveBeenCalledTimes(1);
+
+      // Verify address persisted to secure storage
+      const storedAddress = await secureStorage.getWalletAddress();
+      expect(storedAddress).toBe(mockAddress);
+    });
+
+    it("should connect via Freighter when requestAccess returns string", async () => {
+      mockFreighterApi.isConnected.mockResolvedValue(true);
+      mockFreighterApi.requestAccess.mockResolvedValue(mockAddress);
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("connected");
+      });
+
+      expect(getByTestId("wallet-address").children[0]).toBe(mockAddress);
+      expect(getByTestId("wallet-provider").children[0]).toBe("freighter");
+    });
+
+    it("should connect via Freighter using getPublicKey fallback", async () => {
+      // requestAccess doesn't exist, falls back to getPublicKey
+      mockFreighterApi.isConnected.mockResolvedValue(true);
+      mockFreighterApi.requestAccess.mockResolvedValue(undefined as unknown as string);
+      mockFreighterApi.getPublicKey.mockResolvedValue(mockAddress);
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("connected");
+      });
+
+      expect(getByTestId("wallet-address").children[0]).toBe(mockAddress);
+      expect(getByTestId("wallet-provider").children[0]).toBe("freighter");
+      expect(mockFreighterApi.getPublicKey).toHaveBeenCalledTimes(1);
+    });
+
+    it("should connect via Freighter using getAddress fallback", async () => {
+      // getPublicKey returns undefined, falls back to getAddress
+      mockFreighterApi.isConnected.mockResolvedValue(true);
+      mockFreighterApi.requestAccess.mockResolvedValue(undefined as unknown as string);
+      mockFreighterApi.getPublicKey.mockResolvedValue(undefined as unknown as string);
+      mockFreighterApi.getAddress.mockResolvedValue({ address: mockAddress });
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("connected");
+      });
+
+      expect(getByTestId("wallet-address").children[0]).toBe(mockAddress);
+      expect(getByTestId("wallet-provider").children[0]).toBe("freighter");
+      expect(mockFreighterApi.getAddress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Connection Failure", () => {
+    it("should show error when Freighter is not available", async () => {
+      mockFreighterApi.isConnected.mockResolvedValue(false);
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("error");
+      });
+
+      expect(getByTestId("wallet-error").children[0]).toBe("Freighter is not available");
+      expect(getByTestId("wallet-address").children[0]).toBe("null");
+
+      // No address should be persisted
+      const storedAddress = await secureStorage.getWalletAddress();
+      expect(storedAddress).toBeNull();
+    });
+
+    it("should show error when Freighter returns no address", async () => {
+      mockFreighterApi.isConnected.mockResolvedValue(true);
+      mockFreighterApi.requestAccess.mockResolvedValue(null as unknown as string);
+      mockFreighterApi.getPublicKey.mockResolvedValue(null as unknown as string);
+      mockFreighterApi.getAddress.mockResolvedValue(null as unknown as string);
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("error");
+      });
+
+      expect(getByTestId("wallet-error").children[0]).toBe("No address returned from Freighter");
+      expect(getByTestId("wallet-address").children[0]).toBe("null");
+    });
+
+    it("should retry after Freighter connection failure", async () => {
+      // First attempt: Freighter not available
+      mockFreighterApi.isConnected.mockResolvedValue(false);
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("error");
+      });
+      expect(getByTestId("wallet-error").children[0]).toBe("Freighter is not available");
+
+      // Second attempt: Freighter becomes available
+      mockFreighterApi.isConnected.mockResolvedValue(true);
+      mockFreighterApi.requestAccess.mockResolvedValue({ address: mockAddress });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("connected");
+      });
+
+      expect(getByTestId("wallet-address").children[0]).toBe(mockAddress);
+      expect(mockFreighterApi.isConnected).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Disconnect with Freighter", () => {
+    it("should disconnect Freighter and clear state", async () => {
+      // Connect with Freighter first
+      mockFreighterApi.isConnected.mockResolvedValue(true);
+      mockFreighterApi.requestAccess.mockResolvedValue({ address: mockAddress });
+
+      const { getByTestId } = render(<FreighterTestApp />);
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      await act(async () => {
+        fireEvent.press(getByTestId("connect-freighter-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("connected");
+      });
+
+      // Now disconnect
+      await act(async () => {
+        fireEvent.press(getByTestId("disconnect-btn"));
+      });
+
+      await waitFor(() => {
+        expect(getByTestId("wallet-state").children[0]).toBe("disconnected");
+      });
+
+      expect(getByTestId("wallet-address").children[0]).toBe("null");
+
       const storedAddress = await secureStorage.getWalletAddress();
       expect(storedAddress).toBeNull();
     });

--- a/apps/mobile/app/post/new.tsx
+++ b/apps/mobile/app/post/new.tsx
@@ -156,7 +156,12 @@ export default function CreatePostScreen() {
             </TouchableOpacity>
           </View>
 
-          {/* Over-limit error */}
+          {/* Validation errors */}
+          {isEmpty && (
+            <Text style={styles.errorMsg} accessibilityRole="alert">
+              Post content cannot be empty.
+            </Text>
+          )}
           {overLimit && (
             <Text style={styles.errorMsg} accessibilityRole="alert">
               {`Post is ${Math.abs(remaining)} character${Math.abs(remaining) === 1 ? "" : "s"} over the limit.`}

--- a/apps/mobile/utils/createPost.ts
+++ b/apps/mobile/utils/createPost.ts
@@ -1,7 +1,10 @@
 import { KovaraClient } from "../../../packages/sdk/src/client";
 
 interface WalletKit {
-  signAndSubmitTransaction?: (opts: { txXdr: string; rpcUrl?: string }) => Promise<{ hash?: string; txHash?: string }>;
+  signAndSubmitTransaction?: (opts: {
+    txXdr: string;
+    rpcUrl?: string;
+  }) => Promise<{ hash?: string; txHash?: string }>;
   signTransaction?: (opts: { txXdr: string }) => Promise<{ signedTxXdr: string }>;
 }
 
@@ -14,10 +17,22 @@ export interface CreatePostOptions {
 
 export async function createPost(opts: CreatePostOptions): Promise<string> {
   const { contractId, rpcUrl, author, content } = opts;
+
+  // ── Validation ──────────────────────────────────────────────────────
+  if (!content || content.trim().length === 0) {
+    throw new Error("Post content cannot be empty.");
+  }
+  if (content.length > 280) {
+    throw new Error(
+      `Post content exceeds maximum length of 280 characters (${content.length} chars).`
+    );
+  }
+
   const client = new KovaraClient({ contractId, rpcUrl });
   const txXdr = client.createPost(author, content);
 
-  const kit = (globalThis as unknown as { __Kovara_WALLET_KIT__?: WalletKit }).__Kovara_WALLET_KIT__;
+  const kit = (globalThis as unknown as { __Kovara_WALLET_KIT__?: WalletKit })
+    .__Kovara_WALLET_KIT__;
   if (!kit) throw new Error("Wallet not connected");
 
   if (typeof kit.signAndSubmitTransaction === "function") {

--- a/apps/mobile/utils/sdkCreatePost.ts
+++ b/apps/mobile/utils/sdkCreatePost.ts
@@ -13,6 +13,16 @@ export async function sdkCreatePost(
   content: string,
   walletKit: WalletKitAdapter
 ): Promise<CreatePostResult> {
+  // ── Validation ──────────────────────────────────────────────────────
+  if (!content || content.trim().length === 0) {
+    throw new Error("Post content cannot be empty.");
+  }
+  if (content.length > 280) {
+    throw new Error(
+      `Post content exceeds maximum length of 280 characters (${content.length} chars).`
+    );
+  }
+
   const client = new KovaraClient({ contractId, rpcUrl });
   const txXdr = client.createPost(author, content);
 


### PR DESCRIPTION
## Summary

Fixes for issues assigned to solomon35-stack:

### Issue #132 - Add mobile post composer validation for empty and over-limit content
- Added empty-content validation error message in the post composer UI
- Added content validation (empty + over 280 chars) in `createPost.ts` and `sdkCreatePost.ts` utilities to prevent invalid submissions at the contract level

### Issue #131 - Add mobile wallet connect tests using mocked Freighter or adapter objects
- Added comprehensive Freighter connection test suite with mocked `@stellar/freighter-api`
- Tests cover: successful connection via `requestAccess`, `getPublicKey` fallback, `getAddress` fallback, Freighter not available error, no address error, retry after failure, and disconnect

## Changes
| File | Change |
|------|--------|
| `apps/mobile/app/post/new.tsx` | Add empty-content error message |
| `apps/mobile/utils/createPost.ts` | Add content validation (empty + length) |
| `apps/mobile/utils/sdkCreatePost.ts` | Add content validation (empty + length) |
| `apps/mobile/__tests__/walletConnect.test.tsx` | Add Freighter connection tests |

Closes #132, Closes #131