### PR TITLE
Fixes #129 #128 #74: mobile feed from indexer, error handling, soft-delete tests

### DIFF
--- a/apps/mobile/__tests__/resolvePostSubmitError.test.ts
+++ b/apps/mobile/__tests__/resolvePostSubmitError.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the post-submission error categorizer.
+ *
+ * The composer needs to distinguish user-cancellations from network outages so
+ * it can pick a sensible toast title and retry hint. The categorization lives
+ * in `utils/contractErrors.ts`; these tests pin the mapping semantics.
+ */
+
+import { resolvePostSubmitError, mapContractError } from "../utils/contractErrors";
+
+describe("resolvePostSubmitError", () => {
+  it("classifies user-cancelled transactions", () => {
+    expect(resolvePostSubmitError(new Error("User rejected the request"))).toEqual({
+      code: "USER_REJECTED",
+      message: expect.stringMatching(/cancel/i),
+    });
+
+    expect(resolvePostSubmitError(new Error("Transaction request rejected by the user"))).toEqual({
+      code: "USER_REJECTED",
+      message: expect.stringMatching(/cancel/i),
+    });
+  });
+
+  it("classifies network failures distinctly from rejections", () => {
+    expect(resolvePostSubmitError(new Error("Network request failed"))).toEqual({
+      code: "NETWORK",
+      message: expect.stringMatching(/network/i),
+    });
+
+    expect(resolvePostSubmitError(new Error("connect ETIMEDOUT 1.2.3.4:443"))).toEqual({
+      code: "NETWORK",
+      message: expect.stringMatching(/network/i),
+    });
+
+    expect(resolvePostSubmitError(new Error("TypeError: Failed to fetch"))).toEqual({
+      code: "NETWORK",
+      message: expect.stringMatching(/network/i),
+    });
+  });
+
+  it("classifies wallet-disconnected errors", () => {
+    const err = new Error("Wallet not connected");
+    expect(resolvePostSubmitError(err)).toEqual({
+      code: "WALLET_DISCONNECTED",
+      message: expect.stringMatching(/connect/i),
+    });
+  });
+
+  it("classifies content validation errors raised by the contract", () => {
+    expect(resolvePostSubmitError(new Error("contract error: content too long"))).toEqual({
+      code: "CONTENT_INVALID",
+      message: expect.stringMatching(/invalid/i),
+    });
+
+    expect(resolvePostSubmitError(new Error("contract error: empty content"))).toEqual({
+      code: "CONTENT_INVALID",
+      message: expect.stringMatching(/invalid/i),
+    });
+  });
+
+  it("classifies contract-side authorization errors as UNAUTHORIZED", () => {
+    expect(resolvePostSubmitError(new Error("only author can delete post"))).toEqual({
+      code: "UNAUTHORIZED",
+      message: expect.stringMatching(/not authorized/i),
+    });
+  });
+
+  it("falls back to INTERNAL for unknown errors and uses the legacy mapper", () => {
+    expect(resolvePostSubmitError(new Error("something completely different"))).toEqual({
+      code: "INTERNAL",
+      message: mapContractError(new Error("something completely different")),
+    });
+  });
+
+  it("handles non-Error throwables (strings, null, undefined)", () => {
+    expect(resolvePostSubmitError("user rejected signature")).toEqual({
+      code: "USER_REJECTED",
+      message: expect.stringMatching(/cancel/i),
+    });
+
+    expect(resolvePostSubmitError(null).code).toBe("INTERNAL");
+    expect(resolvePostSubmitError(undefined).code).toBe("INTERNAL");
+  });
+});

--- a/apps/mobile/__tests__/useFeed.test.tsx
+++ b/apps/mobile/__tests__/useFeed.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Tests for the rewritten `useFeed` hook.
+ *
+ * The hook is expected to fetch real data from the indexer REST API rather
+ * than the previously inlined mock `ALL_POSTS` array. These tests exercise:
+ *   - Successful pagination using the indexer's `has_more` flag.
+ *   - Surfacing indexer errors as typed `IndexerError`s via `errorCode`.
+ *   - The deletion-notification bus used by `useDeletePost`.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+import { IndexerError } from "../../../packages/sdk/src/errors";
+import { markFeedPostDeleted, subscribeToFeedPostChanges, useFeed } from "../hooks/useFeed";
+import * as indexerClient from "../utils/indexerClient";
+
+jest.mock("../utils/indexerClient", () => {
+  const actual = jest.requireActual("../utils/indexerClient");
+  return { ...actual, listPosts: jest.fn() };
+});
+
+const mockedListPosts = indexerClient.listPosts as jest.MockedFunction<
+  typeof indexerClient.listPosts
+>;
+
+const samplePost = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  author: "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOP",
+  username: "GABCD…LMNO",
+  content: `Body of ${id}`,
+  tip_total: "0",
+  like_count: 0,
+  created_at: new Date(1700000000 * 1000).toISOString(),
+  deleted: false,
+  ...overrides,
+});
+
+describe("useFeed", () => {
+  beforeEach(() => {
+    mockedListPosts.mockReset();
+  });
+
+  it("loads the first page from the indexer on mount", async () => {
+    mockedListPosts.mockResolvedValueOnce({
+      posts: [samplePost("1"), samplePost("2")],
+      total: 2,
+      hasMore: false,
+    });
+
+    const { result } = renderHook(() => useFeed());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockedListPosts).toHaveBeenCalledWith(expect.any(Number), 0, expect.any(Object));
+    expect(result.current.posts.map((p) => String(p.id))).toEqual(["1", "2"]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("appends the next page on loadMore and stops when has_more is false", async () => {
+    mockedListPosts.mockResolvedValueOnce({
+      posts: [samplePost("1"), samplePost("2")],
+      total: 3,
+      hasMore: true,
+    });
+
+    const { result } = renderHook(() => useFeed());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    mockedListPosts.mockResolvedValueOnce({
+      posts: [samplePost("3")],
+      total: 3,
+      hasMore: false,
+    });
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(result.current.posts).toHaveLength(3));
+    expect(mockedListPosts).toHaveBeenLastCalledWith(expect.any(Number), 2, expect.any(Object));
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("surfaces IndexerError status codes to the caller", async () => {
+    mockedListPosts.mockRejectedValueOnce(new IndexerError("Indexer: service unavailable", 503));
+
+    const { result } = renderHook(() => useFeed());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.errorCode).toBe(503);
+    expect(result.current.error).toMatch(/service unavailable/i);
+    expect(result.current.posts).toEqual([]);
+  });
+
+  it("falls back to a friendly generic message when the error is not an IndexerError", async () => {
+    mockedListPosts.mockRejectedValueOnce(new Error("boom"));
+
+    const { result } = renderHook(() => useFeed());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toMatch(/failed to load posts/i);
+    expect(result.current.errorCode).toBeUndefined();
+  });
+
+  it("filters out posts on markFeedPostDeleted notifications", async () => {
+    mockedListPosts.mockResolvedValueOnce({
+      posts: [samplePost("1"), samplePost("2"), samplePost("3")],
+      total: 3,
+      hasMore: false,
+    });
+
+    const { result } = renderHook(() => useFeed());
+    await waitFor(() => expect(result.current.posts).toHaveLength(3));
+
+    act(() => {
+      markFeedPostDeleted("2");
+    });
+
+    expect(result.current.posts.map((p) => String(p.id))).toEqual(["1", "3"]);
+  });
+
+  it("subscribers are removed when the hook unmounts", () => {
+    const { unmount } = renderHook(() => useFeed());
+    const spy = jest.fn();
+    const unsubscribe = subscribeToFeedPostChanges(spy);
+
+    unmount();
+    unsubscribe();
+
+    // After unmount + unsubscribe, any subsequent deletion must not throw.
+    expect(() => markFeedPostDeleted("999")).not.toThrow();
+  });
+});
+
+describe("postFromIndexer shape", () => {
+  it("converts bigint string ids and numeric fields", async () => {
+    // Importing internals to verify shape handling.
+    const actual = await jest.requireActual("../utils/indexerClient");
+    const post = actual.postFromIndexer({
+      id: "42",
+      author: "GABC…LMNO",
+      content: "hi",
+      tip_total: "123",
+      like_count: "7",
+      created_at: "2024-01-01T00:00:00.000Z",
+    });
+
+    expect(post.id).toBe("42");
+    expect(post.content).toBe("hi");
+    expect(post.tip_total).toBe(123);
+    expect(post.like_count).toBe(7);
+    expect(typeof post.timestamp).toBe("number");
+  });
+});

--- a/apps/mobile/app/post/[id].tsx
+++ b/apps/mobile/app/post/[id].tsx
@@ -1,12 +1,29 @@
 // Post detail screen — shows full content, like count, tip total, author info.
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
 import { useDeletePost } from "../../hooks/useDeletePost";
-import { getFeedPost } from "../../hooks/useFeed";
 import { useWallet } from "../../hooks/useWallet";
 import { useTheme } from "../../theme/useTheme";
+import { getPostById } from "../../utils/indexerClient";
+import type { Post } from "../../components/PostCard";
+import { IndexerError } from "../../../packages/sdk/src/errors";
+import { EmptyState } from "../../components/states/EmptyState";
+import { ErrorState } from "../../components/states/ErrorState";
+import type { IndexerErrorCode } from "../../components/states/ErrorState";
+
+// Status codes renderable by ErrorState; anything else (e.g. 0 from
+// misconfiguration) collapses to 500 so the cast stays type-safe.
+const RENDERABLE_ERROR_CODES: ReadonlySet<IndexerErrorCode> = new Set([
+  400, 401, 403, 404, 429, 500, 502, 503, 504,
+]);
+function clampStatusCode(raw: number | undefined): IndexerErrorCode {
+  if (typeof raw === "number" && RENDERABLE_ERROR_CODES.has(raw as IndexerErrorCode)) {
+    return raw as IndexerErrorCode;
+  }
+  return 500;
+}
 
 type PostParams = {
   id: string;
@@ -19,8 +36,36 @@ export default function PostDetailScreen() {
   const router = useRouter();
   const { address } = useWallet();
   const { deleting, deletePost } = useDeletePost();
-  const post = useMemo(() => (id ? getFeedPost(String(id)) : null), [id]);
-  const isAuthor = Boolean(post && address === post.author);
+  const [post, setPost] = useState<Post | null | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<IndexerErrorCode | undefined>(undefined);
+
+  const refresh = useMemo(
+    () => async () => {
+      if (!id) return;
+      setErrorMessage(null);
+      setErrorCode(undefined);
+      try {
+        const fetched = await getPostById(String(id));
+        setPost(fetched);
+      } catch (err) {
+        if (err instanceof IndexerError) {
+          setErrorCode(clampStatusCode(err.statusCode));
+          setErrorMessage(err.message);
+        } else {
+          setErrorMessage("Could not load this post. Please try again.");
+        }
+        setPost(null);
+      }
+    },
+    [id]
+  );
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const isAuthor = Boolean(post && address && address === post.author);
 
   const handleDeletePress = () => {
     if (!post) {
@@ -42,12 +87,35 @@ export default function PostDetailScreen() {
     ]);
   };
 
+  if (post === undefined) {
+    // Still fetching from the indexer; show a brief placeholder.
+    return (
+      <View style={[styles.container, styles.content]}>
+        <Text style={styles.label}>Post</Text>
+        <Text style={styles.id}>#{id}</Text>
+        <Text style={styles.placeholder}>Loading…</Text>
+      </View>
+    );
+  }
+
+  if (errorMessage && !post) {
+    return (
+      <View style={[styles.container, styles.content]}>
+        <ErrorState message={errorMessage} statusCode={errorCode} onRetry={() => void refresh()} />
+      </View>
+    );
+  }
+
   if (!post) {
     return (
       <View style={[styles.container, styles.content]}>
         <Text style={styles.label}>Post</Text>
         <Text style={styles.id}>#{id}</Text>
-        <Text style={styles.placeholder}>Post not found.</Text>
+        <EmptyState
+          icon="🔍"
+          title="Post not found"
+          subtitle="This post may have been deleted by its author."
+        />
       </View>
     );
   }

--- a/apps/mobile/app/post/new.tsx
+++ b/apps/mobile/app/post/new.tsx
@@ -16,25 +16,11 @@ import { useRouter } from "expo-router";
 import { useWallet } from "../../hooks/useWallet";
 import { useTheme } from "../../theme/useTheme";
 import { useToast } from "../../context/ToastContext";
+import { useCreatePost } from "../../hooks/useCreatePost";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const MAX_CHARS = 280;
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Stub for the real contract call.
- * Replace with `KovaraClient.createPost(author, content)` once the SDK is wired.
- */
-async function submitCreatePost(_author: string, _content: string): Promise<string> {
-  // TODO: replace with real SDK call, e.g.:
-  // const client = new KovaraClient({ contractId: CONTRACT_ID, rpcUrl: RPC_URL });
-  // const postId = await client.createPost(author, content);
-  // return String(postId);
-  await new Promise((r) => setTimeout(r, 1200)); // simulate network
-  return String(Math.floor(Math.random() * 10_000) + 1);
-}
 
 // ── Screen ───────────────────────────────────────────────────────────────────
 
@@ -43,9 +29,9 @@ export default function CreatePostScreen() {
   const { theme } = useTheme();
   const { address, connected } = useWallet();
   const { showPending, showSuccess, showError, dismissToast } = useToast();
+  const { submitting, submit } = useCreatePost();
 
   const [content, setContent] = useState("");
-  const [submitting, setSubmitting] = useState(false);
 
   const remaining = MAX_CHARS - content.length;
   const overLimit = remaining < 0;
@@ -61,21 +47,42 @@ export default function CreatePostScreen() {
   const handleSubmit = useCallback(async () => {
     if (submitDisabled || !address) return;
 
-    setSubmitting(true);
     showPending();
 
-    try {
-      const postId = await submitCreatePost(address, content.trim());
-      dismissToast();
-      showSuccess(postId);
-      // Navigate to the new post detail screen
-      router.replace(`/post/${postId}` as Parameters<typeof router.replace>[0]);
-    } catch (err) {
-      dismissToast();
-      showError(err instanceof Error ? err.message : "Failed to publish post.");
-      setSubmitting(false);
+    const result = await submit({ content });
+
+    // The pending toast must be dismissed in every flow: success, error, or
+    // already shown validation message.
+    dismissToast();
+
+    if (result.ok) {
+      showSuccess(result.txHash || result.postId);
+      router.replace(`/post/${result.postId}` as Parameters<typeof router.replace>[0]);
+      setContent("");
+    } else {
+      // Different failure categories get a slightly different title so the
+      // user has a hint about whether retrying will help.
+      const title =
+        result.code === "USER_REJECTED"
+          ? "Transaction canceled"
+          : result.code === "WALLET_DISCONNECTED"
+            ? "Wallet not connected"
+            : result.code === "NETWORK"
+              ? "Network error"
+              : "Failed to publish post";
+      showError(result.message, title);
     }
-  }, [submitDisabled, address, content, router, showPending, showSuccess, showError, dismissToast]);
+  }, [
+    submitDisabled,
+    address,
+    content,
+    router,
+    showPending,
+    showSuccess,
+    showError,
+    dismissToast,
+    submit,
+  ]);
 
   const styles = useMemo(() => createStyles(theme), [theme]);
 

--- a/apps/mobile/context/ToastContext.tsx
+++ b/apps/mobile/context/ToastContext.tsx
@@ -20,7 +20,7 @@ interface ToastContextValue {
   showPending: () => void;
   showSuccess: (txHash: string) => void;
   /** Show an error toast for failed transactions or wallet operations. */
-  showError: (message: string) => void;
+  showError: (message: string, title?: string) => void;
   /** Show an error toast specifically for indexer / data-fetch failures (non-200 responses). */
   showIndexerError: (message?: string) => void;
 }
@@ -60,10 +60,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }): JSX.
   );
 
   const showError = useCallback(
-    (message: string) => {
+    (message: string, title?: string) => {
       showToast({
         kind: "error",
-        title: "Transaction failed",
+        title: title ?? "Transaction failed",
         message,
       });
     },

--- a/apps/mobile/hooks/useCreatePost.ts
+++ b/apps/mobile/hooks/useCreatePost.ts
@@ -1,0 +1,130 @@
+import { useCallback, useState } from "react";
+
+import { useNetwork } from "./useNetwork";
+import { useWallet } from "./useWallet";
+import { createPost as createPostOnChain } from "../utils/createPost";
+import { resolvePostSubmitError } from "../utils/contractErrors";
+
+export interface SubmitPostInput {
+  content: string;
+}
+
+export interface SubmitPostSuccess {
+  ok: true;
+  /** Transaction hash returned by the wallet / Soroban RPC. */
+  txHash: string;
+  /** Post id reported by the contract (best-effort, may equal `txHash` if not yet indexed). */
+  postId: string;
+}
+
+export interface SubmitPostFailure {
+  ok: false;
+  /** Friendly, user-facing description of why the submission failed. */
+  message: string;
+  /** Stable category code for branching on the failure mode in the UI. */
+  code:
+    | "WALLET_DISCONNECTED"
+    | "USER_REJECTED"
+    | "CONTENT_INVALID"
+    | "UNAUTHORIZED"
+    | "NETWORK"
+    | "INTERNAL";
+  /** Underlying error (kept for logging / Send-to-support flows). */
+  cause: unknown;
+}
+
+export type SubmitPostResult = SubmitPostSuccess | SubmitPostFailure;
+
+const MAX_CONTENT_LEN = 280;
+
+function validateContent(content: string): string | null {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return "Post content cannot be empty.";
+  }
+  if (trimmed.length > MAX_CONTENT_LEN) {
+    return `Post is too long (${trimmed.length}/${MAX_CONTENT_LEN} characters).`;
+  }
+  return null;
+}
+
+export interface UseCreatePostReturn {
+  submitting: boolean;
+  error: string | null;
+  /** Reset the local error state, e.g. when the user edits the composer. */
+  clearError: () => void;
+  submit: (input: SubmitPostInput) => Promise<SubmitPostResult>;
+}
+
+/**
+ * Hook that exposes a typed `submit` helper for publishing new posts.
+ *
+ * This is the bridge between the post composer screen and the on-chain
+ * `create_post` transaction. It:
+ *   1. Pulls `contractId` and `rpcUrl` from the active network context.
+ *   2. Pulls the connected wallet address from the wallet context.
+ *   3. Delegates the actual transaction to `utils/createPost.ts`.
+ *   4. Maps every thrown error into a friendly message + stable code.
+ *
+ * The hook itself never throws — callers always receive a discriminated
+ * `SubmitPostResult` so they can branch on `ok` without try/catch.
+ */
+export function useCreatePost(): UseCreatePostReturn {
+  const { contractId, rpcUrl } = useNetwork();
+  const { address, connected, wallet } = useWallet();
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const submit = useCallback(
+    async ({ content }: SubmitPostInput): Promise<SubmitPostResult> => {
+      setError(null);
+
+      const trimmed = content.trim();
+      const validation = validateContent(trimmed);
+      if (validation) {
+        setError(validation);
+        return { ok: false, message: validation, code: "CONTENT_INVALID", cause: null };
+      }
+
+      if (!connected || !address) {
+        const message = "Connect your wallet to publish this post.";
+        setError(message);
+        return { ok: false, message, code: "WALLET_DISCONNECTED", cause: null };
+      }
+
+      // Some wallets outlive the `connected` flag momentarily after the user
+      // has revoked; guard here so we surface a clean error instead of a
+      // contract-side auth failure.
+      if (!wallet) {
+        const message = "Your wallet session has expired. Reconnect and try again.";
+        setError(message);
+        return { ok: false, message, code: "WALLET_DISCONNECTED", cause: null };
+      }
+
+      setSubmitting(true);
+      try {
+        const txHash = await createPostOnChain({
+          contractId,
+          rpcUrl,
+          author: address,
+          content: trimmed,
+        });
+
+        const postId = txHash ? txHash.slice(0, 16) : String(Date.now());
+        return { ok: true, txHash, postId };
+      } catch (cause) {
+        const resolved = resolvePostSubmitError(cause);
+        setError(resolved.message);
+        return { ok: false, message: resolved.message, code: resolved.code, cause };
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [address, connected, contractId, rpcUrl, wallet]
+  );
+
+  return { submitting, error, clearError, submit };
+}

--- a/apps/mobile/hooks/useFeed.ts
+++ b/apps/mobile/hooks/useFeed.ts
@@ -1,165 +1,49 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+
 import { Post } from "../components/PostCard";
 import { IndexerError } from "../../../packages/sdk/src/errors";
 import type { IndexerErrorCode } from "../components/states/ErrorState";
+import { listPosts as fetchPostsFromIndexer } from "../utils/indexerClient";
 
 const PAGE_SIZE = 10;
-const deletedPostIds = new Set<string>();
-const deleteListeners = new Set<() => void>();
 
-const ALL_POSTS: Post[] = [
-  {
-    id: 1,
-    author: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "stellar_dev",
-    content: "Just deployed my first smart contract on Stellar! 🚀",
-    tip_total: 100,
-    timestamp: Math.floor(Date.now() / 1000) - 3600,
-    like_count: 5,
-  },
-  {
-    id: 2,
-    author: "GXYZ9876543210ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "crypto_enthusiast",
-    content: "The SocialFi ecosystem is growing fast. Excited to be part of it!",
-    tip_total: 50,
-    timestamp: Math.floor(Date.now() / 1000) - 7200,
-    like_count: 3,
-  },
-  {
-    id: 3,
-    author: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "stellar_dev",
-    content: "Working on a new DeFi protocol. Stay tuned! 🔥",
-    tip_total: 200,
-    timestamp: Math.floor(Date.now() / 1000) - 14400,
-    like_count: 12,
-  },
-  {
-    id: 4,
-    author: "GDEF5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "Kovara_fan",
-    content: "Kovara is the future of decentralised social. #Stellar",
-    tip_total: 75,
-    timestamp: Math.floor(Date.now() / 1000) - 21600,
-    like_count: 8,
-  },
-  {
-    id: 5,
-    author: "GHIJ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "soroban_builder",
-    content: "Soroban smart contracts make on-chain social possible. 🌟",
-    tip_total: 300,
-    timestamp: Math.floor(Date.now() / 1000) - 28800,
-    like_count: 20,
-  },
-];
+// Status codes rendered as badges in the ErrorState component. Anything
+// outside this set falls back to `500` so the cast in `setErrorCode` stays
+// type-safe.
+const RENDERABLE_ERROR_CODES: ReadonlySet<IndexerErrorCode> = new Set([
+  400, 401, 403, 404, 429, 500, 502, 503, 504,
+]);
 
-function isDeleted(postId: Post["id"]): boolean {
-  return deletedPostIds.has(String(postId));
-}
-
-export function getFeedPostById(postId: string): Post | null {
-  return ALL_POSTS.find((post) => String(post.id) === postId && !isDeleted(post.id)) ?? null;
-}
-
-export function markFeedPostDeleted(postId: string | number): void {
-  deletedPostIds.add(String(postId));
-  deleteListeners.forEach((listener) => listener());
-}
-
-export function subscribeToDeletedPosts(listener: () => void): () => void {
-  deleteListeners.add(listener);
-  return () => {
-    deleteListeners.delete(listener);
-  };
-}
-
-const ALL_POSTS: Post[] = [
-  {
-    id: 1,
-    author: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "stellar_dev",
-    content: "Just deployed my first smart contract on Stellar!",
-    tip_total: 100,
-    timestamp: Math.floor(Date.now() / 1000) - 3600,
-    like_count: 5,
-  },
-  {
-    id: 2,
-    author: "GXYZ9876543210ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "crypto_enthusiast",
-    content: "The SocialFi ecosystem is growing fast. Excited to be part of it!",
-    tip_total: 50,
-    timestamp: Math.floor(Date.now() / 1000) - 7200,
-    like_count: 3,
-  },
-  {
-    id: 3,
-    author: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "stellar_dev",
-    content: "Working on a new DeFi protocol. Stay tuned!",
-    tip_total: 200,
-    timestamp: Math.floor(Date.now() / 1000) - 14400,
-    like_count: 12,
-  },
-  {
-    id: 4,
-    author: "GDEF5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "Kovara_fan",
-    content: "Kovara is the future of decentralised social. #Stellar",
-    tip_total: 75,
-    timestamp: Math.floor(Date.now() / 1000) - 21600,
-    like_count: 8,
-  },
-  {
-    id: 5,
-    author: "GHIJ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    username: "soroban_builder",
-    content: "Soroban smart contracts make on-chain social possible.",
-    tip_total: 300,
-    timestamp: Math.floor(Date.now() / 1000) - 28800,
-    like_count: 20,
-  },
-];
-
-const deletedPostIds = new Set<string>();
-const postChangeListeners = new Set<(deletedPostId: string) => void>();
-
-export function getFeedPost(postId: string): Post | null {
-  if (deletedPostIds.has(postId)) {
-    return null;
+function clampStatusCode(raw: number | undefined): IndexerErrorCode {
+  if (typeof raw === "number" && RENDERABLE_ERROR_CODES.has(raw as IndexerErrorCode)) {
+    return raw as IndexerErrorCode;
   }
-
-  return ALL_POSTS.find((post) => String(post.id) === postId) ?? null;
-}
-
-export function markFeedPostDeleted(postId: string): void {
-  deletedPostIds.add(postId);
-  postChangeListeners.forEach((listener) => listener(postId));
-}
-
-export function subscribeToFeedPostChanges(listener: (deletedPostId: string) => void): () => void {
-  postChangeListeners.add(listener);
-  return () => {
-    postChangeListeners.delete(listener);
-  };
+  return 500;
 }
 
 /**
- * Fetches a page of posts using cursor-based pagination.
- *
- * Replace the mock implementation with real `get_post` contract calls
- * once the Soroban client is wired up.
+ * Module-level listener set used to broadcast soft-deletes from any screen
+ * to any useFeed instance. IDs are kept as strings to stay consistent with
+ * the PostCard's key extraction.
  */
-async function fetchPostPage(cursor: number, limit: number): Promise<Post[]> {
-  await new Promise<void>((resolve) => setTimeout(resolve, 400));
+const deletionListeners = new Set<(deletedPostId: string) => void>();
 
-  const visiblePosts = ALL_POSTS.filter((post) => !deletedPostIds.has(String(post.id)));
+/**
+ * Notify every mounted `useFeed` that a post was soft-deleted so the post
+ * can be removed from its local cache immediately. Used by `useDeletePost`
+ * after a successful indexer delete-deletion, and by the post detail screen
+ * after a confirmed deletion.
+ */
+export function markFeedPostDeleted(postId: string | number): void {
+  const id = String(postId);
+  deletionListeners.forEach((listener) => listener(id));
+}
 
-  // cursor is the last seen post id (0 = start from beginning)
-  const startIndex = cursor === 0 ? 0 : visiblePosts.findIndex((p) => p.id === cursor) + 1;
-  return visiblePosts.slice(startIndex, startIndex + limit);
+export function subscribeToFeedPostChanges(listener: (deletedPostId: string) => void): () => void {
+  deletionListeners.add(listener);
+  return () => {
+    deletionListeners.delete(listener);
+  };
 }
 
 export interface UseFeedReturn {
@@ -179,11 +63,10 @@ export function useFeed(): UseFeedReturn {
   const [errorCode, setErrorCode] = useState<IndexerErrorCode | undefined>(undefined);
   const [hasMore, setHasMore] = useState(true);
 
-  // cursor = id of the last loaded post (0 = initial load)
-  const cursorRef = useRef<number>(0);
+  const offsetRef = useRef(0);
   const loadingRef = useRef(false);
 
-  const load = useCallback(async (cursor: number, replace: boolean) => {
+  const load = useCallback(async (offset: number, replace: boolean) => {
     if (loadingRef.current) return;
     loadingRef.current = true;
     setLoading(true);
@@ -191,15 +74,15 @@ export function useFeed(): UseFeedReturn {
     setErrorCode(undefined);
 
     try {
-      const fetched = await fetchPostPage(cursor, PAGE_SIZE);
+      const { posts: fetched, hasMore: more } = await fetchPostsFromIndexer(PAGE_SIZE, offset, {});
       setPosts((prev) => (replace ? fetched : [...prev, ...fetched]));
-      setHasMore(fetched.length >= PAGE_SIZE);
+      setHasMore(more);
       if (fetched.length > 0) {
-        cursorRef.current = Number(fetched[fetched.length - 1].id);
+        offsetRef.current = offset + fetched.length;
       }
     } catch (e) {
       if (e instanceof IndexerError) {
-        setErrorCode(e.statusCode as IndexerErrorCode);
+        setErrorCode(clampStatusCode(e.statusCode));
         setError(e.message);
       } else {
         setError("Failed to load posts. Please try again.");
@@ -211,7 +94,8 @@ export function useFeed(): UseFeedReturn {
   }, []);
 
   useEffect(() => {
-    load(0, true);
+    offsetRef.current = 0;
+    void load(0, true);
   }, [load]);
 
   useEffect(() => {
@@ -222,13 +106,13 @@ export function useFeed(): UseFeedReturn {
 
   const loadMore = useCallback(() => {
     if (!loading && hasMore) {
-      load(cursorRef.current, false);
+      void load(offsetRef.current, false);
     }
   }, [loading, hasMore, load]);
 
   const refresh = useCallback(() => {
-    cursorRef.current = 0;
-    load(0, true);
+    offsetRef.current = 0;
+    void load(0, true);
   }, [load]);
 
   return { posts, loading, error, errorCode, hasMore, loadMore, refresh };

--- a/apps/mobile/utils/contractErrors.ts
+++ b/apps/mobile/utils/contractErrors.ts
@@ -1,3 +1,13 @@
+/**
+ * Resolves raw thrown values from the on-chain `createPost` (and other
+ * mobile write helpers) into friendly, user-facing strings the composer can
+ * display without ever leaking Soroban internals.
+ *
+ * This module is the single source of truth for "what message do we show the
+ * user when X happens?".  Callers should NOT inspect raw `err.message` in UI
+ * code — they should call `mapContractError` or `resolvePostSubmitError`.
+ */
+
 export type ContractErrorCode =
   | "UNAUTHORIZED"
   | "INVALID_STATE"
@@ -14,18 +24,148 @@ const MESSAGES: Record<ContractErrorCode, string> = {
 };
 
 export function mapContractError(error: unknown): string {
-  if (!(error instanceof Error)) return MESSAGES.UNKNOWN;
+  if (!(error instanceof Error)) {
+    return MESSAGES.UNKNOWN;
+  }
 
   const msg = error.message.toLowerCase();
 
-  if (msg.includes("unauthorized") || msg.includes("auth"))
+  if (msg.includes("unauthorized") || msg.includes("auth")) {
     return MESSAGES.UNAUTHORIZED;
-  if (msg.includes("invalid") || msg.includes("state"))
+  }
+  if (msg.includes("invalid") || msg.includes("state")) {
     return MESSAGES.INVALID_STATE;
-  if (msg.includes("not found") || msg.includes("notfound"))
+  }
+  if (msg.includes("not found") || msg.includes("notfound")) {
     return MESSAGES.NOT_FOUND;
-  if (msg.includes("already") || msg.includes("exists"))
+  }
+  if (msg.includes("already") || msg.includes("exists")) {
     return MESSAGES.ALREADY_EXISTS;
+  }
 
   return MESSAGES.UNKNOWN;
+}
+
+// ── Post-submission specific categorization ──────────────────────────────────
+//
+// Going beyond the coarse-grained `mapContractError`, post submission needs
+// distinct buckets so the UI can:
+//   - Show a different toast title for "you cancelled" vs "wallet offline".
+//   - Optionally retry on transient network errors but not on user rejections.
+
+export type PostSubmitErrorCode =
+  | "WALLET_DISCONNECTED"
+  | "USER_REJECTED"
+  | "CONTENT_INVALID"
+  | "UNAUTHORIZED"
+  | "NETWORK"
+  | "INTERNAL";
+
+export interface PostSubmitError {
+  message: string;
+  code: PostSubmitErrorCode;
+}
+
+const USER_REJECTED_PATTERNS = [
+  "user rejected",
+  "user declined",
+  "user cancelled",
+  "user canceled",
+  "request rejected",
+  "transaction declined",
+  "transaction canceled",
+  "transaction cancelled",
+  "denied by the user",
+  "rejected by user",
+];
+
+const NETWORK_PATTERNS = [
+  "network",
+  "timeout",
+  "timed out",
+  "etimedout",
+  "econnrefused",
+  "econnreset",
+  "enotfound",
+  "failed to fetch",
+  "fetch failed",
+  "fetch api",
+];
+
+function matchesAny(haystack: string, needles: string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function extractMessage(err: unknown): string {
+  if (err instanceof Error) return err.message.toLowerCase();
+  if (typeof err === "string") return err.toLowerCase();
+  try {
+    return String(err).toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Resolve any error thrown by the post-submission pipeline into a friendly
+ * message + stable category code. Used by `useCreatePost` so the entire
+ * composer can branch off a discriminated union instead of try/catching.
+ */
+export function resolvePostSubmitError(err: unknown): PostSubmitError {
+  // Null / undefined is treated as an internal error — caller should never
+  // throw nothing, but be defensive.
+  if (err === null || err === undefined) {
+    return { code: "INTERNAL", message: MESSAGES.UNKNOWN };
+  }
+
+  const message = extractMessage(err);
+
+  // Order matters: specific categories must be tested before the catch-all
+  // `mapContractError`/UNKNOWN fallback.
+  if (matchesAny(message, USER_REJECTED_PATTERNS)) {
+    return { code: "USER_REJECTED", message: "You canceled the transaction." };
+  }
+
+  if (matchesAny(message, NETWORK_PATTERNS)) {
+    return {
+      code: "NETWORK",
+      message: "Network error. Check your connection and try again.",
+    };
+  }
+
+  if (
+    message.includes("wallet") &&
+    (message.includes("not connected") || message.includes("disconnected"))
+  ) {
+    return {
+      code: "WALLET_DISCONNECTED",
+      message: "Your wallet is not connected. Reconnect and try again.",
+    };
+  }
+
+  if (message.includes("content too long") || message.includes("empty content")) {
+    return {
+      code: "CONTENT_INVALID",
+      message: "Post content is invalid (empty or too long).",
+    };
+  }
+
+  if (message.includes("unauthorized") || message.includes("only author")) {
+    return {
+      code: "UNAUTHORIZED",
+      message: "You are not authorized to perform this action.",
+    };
+  }
+
+  if (message.includes("invalid")) {
+    return {
+      code: "CONTENT_INVALID",
+      message: "Post content is invalid (empty or too long).",
+    };
+  }
+
+  // Fall back to the coarse-grained map for everything else and tag it as
+  // internal. This keeps user-facing copy consistent with the rest of the
+  // app for shared error patterns.
+  return { code: "INTERNAL", message: mapContractError(err) };
 }

--- a/apps/mobile/utils/indexerClient.ts
+++ b/apps/mobile/utils/indexerClient.ts
@@ -1,0 +1,180 @@
+/**
+ * Thin client around the Kovara indexer REST API.
+ *
+ * Centralises fetch calls so the rest of the mobile app does not have to
+ * duplicate URL construction, error mapping, or response parsing. The indexer
+ * is the canonical source for paginated, post-tx data (the SDK only fetches
+ * one post at a time from the Soroban RPC).
+ *
+ * Environment variable:
+ *   EXPO_PUBLIC_INDEXER_URL  - Base URL of the indexer (e.g. https://indexer.kovara.io).
+ *                              The trailing slash is stripped automatically.
+ *                              When unset, fetches will fail with `IndexerError`
+ *                              so the UI can show a clear configuration error to
+ *                              the user instead of silently using mock data.
+ */
+
+import { IndexerError, mapHttpError } from "../../../packages/sdk/src/errors";
+import type { Post } from "../components/PostCard";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+function getBaseUrl(): string {
+  const raw = process.env.EXPO_PUBLIC_INDEXER_URL;
+  if (!raw) {
+    throw new IndexerError(
+      "EXPO_PUBLIC_INDEXER_URL is not configured. Set it in your .env to enable feed loading.",
+      0
+    );
+  }
+  return raw.replace(/\/+$/, "");
+}
+
+function shortAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+interface IndexerPostRow {
+  id: string;
+  author: string;
+  content: string;
+  tip_total: string | number;
+  like_count: string | number;
+  created_at?: string | null;
+  deleted?: boolean;
+  deleted_at?: string | null;
+}
+
+interface IndexerListResponse {
+  posts: IndexerPostRow[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+interface IndexerOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+async function request<T>(
+  path: string,
+  init: RequestInit = {},
+  opts: IndexerOptions = {}
+): Promise<T> {
+  const base = getBaseUrl();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  // Chain the caller's signal into ours so external aborts still propagate.
+  if (opts.signal) {
+    if (opts.signal.aborted) controller.abort();
+    else opts.signal.addEventListener("abort", () => controller.abort(), { once: true });
+  }
+
+  try {
+    const res = await fetch(`${base}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: { Accept: "application/json", ...(init.headers ?? {}) },
+    });
+
+    const text = await res.text();
+    if (!res.ok) {
+      throw mapHttpError(res.status, text.slice(0, 500));
+    }
+
+    try {
+      return JSON.parse(text) as T;
+    } catch (parseErr) {
+      throw new IndexerError(
+        `Indexer returned malformed JSON: ${(parseErr as Error).message}`,
+        res.status,
+        parseErr
+      );
+    }
+  } catch (err) {
+    if (err instanceof IndexerError) throw err;
+    if ((err as Error).name === "AbortError") {
+      throw new IndexerError("Indexer request was aborted or timed out", 0, err);
+    }
+    throw new IndexerError(`Could not reach the indexer: ${(err as Error).message}`, 0, err);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Convert an indexer row into the Post shape used by PostCard / useFeed.
+ *
+ * The indexer returns IDs as bigint strings and `tip_total`/`like_count`
+ * can be either number or string depending on serialization. Username is not
+ * stored by the indexer, so we fall back to a shortened address; profile
+ * lookups can be layered in later without breaking this contract.
+ */
+export function postFromIndexer(row: IndexerPostRow): Post {
+  const author = String(row.author ?? "");
+  const createdAtMs = row.created_at ? new Date(row.created_at).getTime() : Date.now();
+
+  return {
+    id: row.id,
+    author,
+    // Profile display name is filled in by a separate lookup when available.
+    username: shortAddress(author),
+    content: String(row.content ?? ""),
+    tip_total:
+      typeof row.tip_total === "string" ? Number(row.tip_total) : Number(row.tip_total ?? 0),
+    timestamp: Math.floor(createdAtMs / 1000),
+    like_count:
+      typeof row.like_count === "string" ? Number(row.like_count) : Number(row.like_count ?? 0),
+  };
+}
+
+/**
+ * Fetch a page of posts from the indexer using limit/offset pagination.
+ *
+ * @param limit  How many posts to request (1-100, the indexer caps at 100).
+ * @param offset How many posts to skip before returning results.
+ */
+export async function listPosts(
+  limit = 20,
+  offset = 0,
+  opts: IndexerOptions = {}
+): Promise<{ posts: Post[]; total: number; hasMore: boolean }> {
+  const safeLimit = Math.min(Math.max(1, Math.floor(limit)), 100);
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const qs = new URLSearchParams({ limit: String(safeLimit), offset: String(safeOffset) });
+
+  const data = await request<IndexerListResponse>(`/api/posts?${qs.toString()}`, {}, opts);
+  return {
+    posts: (data.posts ?? []).map(postFromIndexer),
+    total: Number(data.total ?? 0),
+    hasMore: Boolean(data.has_more),
+  };
+}
+
+/**
+ * Fetch a single post by its indexer-assigned id.
+ *
+ * Returns null if the indexer reports the post as soft-deleted so callers can
+ * distinguish between "not found" and "deleted by its author".
+ */
+export async function getPostById(
+  postId: string | number,
+  opts: IndexerOptions = {}
+): Promise<Post | null> {
+  try {
+    const row = await request<IndexerPostRow>(
+      `/api/posts/${encodeURIComponent(String(postId))}`,
+      {},
+      opts
+    );
+    if (row.deleted || row.deleted_at) return null;
+    return postFromIndexer(row);
+  } catch (err) {
+    if (err instanceof IndexerError && err.statusCode === 404) return null;
+    throw err;
+  }
+}

--- a/services/indexer/src/db.ts
+++ b/services/indexer/src/db.ts
@@ -132,9 +132,22 @@ export class PostgresDatabase implements Database {
       tip_total: this.toBigInt(row.tip_total ?? 0),
       like_count: this.toBigInt(row.like_count ?? 0),
       created_ledger: Number(row.created_ledger ?? 0),
-      deleted_ledger: row.deleted_ledger === null || row.deleted_ledger === undefined ? null : Number(row.deleted_ledger),
-      created_at: row.created_at instanceof Date ? row.created_at : row.created_at ? new Date(String(row.created_at)) : null,
-      deleted_at: row.deleted_at instanceof Date ? row.deleted_at : row.deleted_at ? new Date(String(row.deleted_at)) : null,
+      deleted_ledger:
+        row.deleted_ledger === null || row.deleted_ledger === undefined
+          ? null
+          : Number(row.deleted_ledger),
+      created_at:
+        row.created_at instanceof Date
+          ? row.created_at
+          : row.created_at
+            ? new Date(String(row.created_at))
+            : null,
+      deleted_at:
+        row.deleted_at instanceof Date
+          ? row.deleted_at
+          : row.deleted_at
+            ? new Date(String(row.deleted_at))
+            : null,
     };
   }
 
@@ -177,7 +190,13 @@ export class PostgresDatabase implements Database {
       VALUES ($1, $2, $3, $4, $5, NOW())
       ON CONFLICT (id) DO NOTHING
       `,
-      [post.id.toString(), post.author, post.content, post.tip_total.toString(), post.like_count.toString()]
+      [
+        post.id.toString(),
+        post.author,
+        post.content,
+        post.tip_total.toString(),
+        post.like_count.toString(),
+      ]
     );
   }
 
@@ -206,7 +225,14 @@ export class PostgresDatabase implements Database {
   }
 
   async getPost(post_id: bigint): Promise<Post | null> {
-    const result = await this.pool.query(`SELECT * FROM posts WHERE id = $1`, [post_id.toString()]);
+    // Soft-delete: rows with a non-null `deleted_at` are treated as gone and
+    // surface as `null` so the REST endpoint returns the same 404 it would
+    // for a post that never existed. This matches the README/indexer spec
+    // and keeps testing simple: callers don’t have to inspect `deleted`.
+    const result = await this.pool.query(
+      `SELECT * FROM posts WHERE id = $1 AND deleted_at IS NULL`,
+      [post_id.toString()]
+    );
     return result.rowCount ? this.mapPost(result.rows[0]) : null;
   }
 
@@ -230,7 +256,14 @@ export class PostgresDatabase implements Database {
       VALUES ($1, $2, $3, $4, $5, $6)
       ON CONFLICT (tx_hash) DO NOTHING
       `,
-      [tip.tipper, tip.post_id.toString(), tip.amount.toString(), tip.fee.toString(), tip.ledger, tip.tx_hash]
+      [
+        tip.tipper,
+        tip.post_id.toString(),
+        tip.amount.toString(),
+        tip.fee.toString(),
+        tip.ledger,
+        tip.tx_hash,
+      ]
     );
   }
 
@@ -246,7 +279,15 @@ export class PostgresDatabase implements Database {
         threshold = EXCLUDED.threshold,
         updated_ledger = EXCLUDED.updated_ledger
       `,
-      [pool.pool_id, pool.token, pool.balance.toString(), pool.admins, pool.threshold, pool.created_ledger, pool.updated_ledger]
+      [
+        pool.pool_id,
+        pool.token,
+        pool.balance.toString(),
+        pool.admins,
+        pool.threshold,
+        pool.created_ledger,
+        pool.updated_ledger,
+      ]
     );
   }
 
@@ -268,7 +309,15 @@ export class PostgresDatabase implements Database {
       VALUES ($1, $2, $3, $4, $5, $6, $7)
       ON CONFLICT (pool_id) DO NOTHING
       `,
-      [pool.pool_id, pool.token, pool.balance.toString(), pool.admins, pool.threshold, pool.created_ledger, pool.updated_ledger]
+      [
+        pool.pool_id,
+        pool.token,
+        pool.balance.toString(),
+        pool.admins,
+        pool.threshold,
+        pool.created_ledger,
+        pool.updated_ledger,
+      ]
     );
   }
 
@@ -304,7 +353,11 @@ export class PostgresDatabase implements Database {
     return result.rowCount ? (result.rows[0] as Profile) : null;
   }
 
-  async listPosts(filters: { author?: string; limit: number; offset: number }): Promise<{ posts: Post[]; total: number }> {
+  async listPosts(filters: {
+    author?: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ posts: Post[]; total: number }> {
     const { author, limit, offset } = filters;
     const values: unknown[] = [];
     let whereClause = "WHERE deleted_at IS NULL";
@@ -314,7 +367,10 @@ export class PostgresDatabase implements Database {
       whereClause += ` AND author = $${values.length}`;
     }
 
-    const countResult = await this.pool.query(`SELECT COUNT(*)::int AS total FROM posts ${whereClause}`, values);
+    const countResult = await this.pool.query(
+      `SELECT COUNT(*)::int AS total FROM posts ${whereClause}`,
+      values
+    );
     const result = await this.pool.query(
       `SELECT * FROM posts ${whereClause} ORDER BY created_at DESC LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
       [...values, limit, offset]
@@ -326,7 +382,11 @@ export class PostgresDatabase implements Database {
     };
   }
 
-  async searchPosts(filters: { query: string; limit: number; offset: number }): Promise<{ posts: Post[]; total: number }> {
+  async searchPosts(filters: {
+    query: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ posts: Post[]; total: number }> {
     const { query, limit, offset } = filters;
     const normalizedQuery = query.trim();
 
@@ -364,8 +424,15 @@ export class PostgresDatabase implements Database {
     };
   }
 
-  async getFollowers(address: string, limit: number, offset: number): Promise<{ followers: string[]; total: number }> {
-    const countResult = await this.pool.query(`SELECT COUNT(*)::int AS total FROM follows WHERE followee = $1`, [address]);
+  async getFollowers(
+    address: string,
+    limit: number,
+    offset: number
+  ): Promise<{ followers: string[]; total: number }> {
+    const countResult = await this.pool.query(
+      `SELECT COUNT(*)::int AS total FROM follows WHERE followee = $1`,
+      [address]
+    );
     const result = await this.pool.query(
       `SELECT follower FROM follows WHERE followee = $1 ORDER BY follower LIMIT $2 OFFSET $3`,
       [address, limit, offset]
@@ -377,8 +444,15 @@ export class PostgresDatabase implements Database {
     };
   }
 
-  async getFollowing(address: string, limit: number, offset: number): Promise<{ following: string[]; total: number }> {
-    const countResult = await this.pool.query(`SELECT COUNT(*)::int AS total FROM follows WHERE follower = $1`, [address]);
+  async getFollowing(
+    address: string,
+    limit: number,
+    offset: number
+  ): Promise<{ following: string[]; total: number }> {
+    const countResult = await this.pool.query(
+      `SELECT COUNT(*)::int AS total FROM follows WHERE follower = $1`,
+      [address]
+    );
     const result = await this.pool.query(
       `SELECT followee FROM follows WHERE follower = $1 ORDER BY followee LIMIT $2 OFFSET $3`,
       [address, limit, offset]

--- a/services/indexer/src/handlers/__tests__/post.test.ts
+++ b/services/indexer/src/handlers/__tests__/post.test.ts
@@ -85,5 +85,46 @@ describe("Post Event Handlers", () => {
 
       await expect(handlePostDeleted(mockPool, event, context)).rejects.toThrow("DB error");
     });
+
+    // ── Soft-delete semantics (issue #74) ──────────────────────────────────────
+    //
+    // The contract emits PostDeleted for every successful on-chain delete, but
+    // the on-chain `delete_post` is a hard-remove (the post entry is removed
+    // from storage entirely).  This means the indexer's soft-delete is a
+    // *defensive* signal: when the DB row still exists at the time of the
+    // event (e.g. replication lag), the handler should set `deleted_at`.  When
+    // the row has already been removed the idempotent skip is safe.  These
+    // tests pin that semantics so regressions in either direction are loud.
+
+    it("issues the same UPDATE shape for both first delete and replay", async () => {
+      const { event, context } = createMockPostDeletedEvent(7n, "GTEST123");
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+      await handlePostDeleted(mockPool, event, context);
+      const firstCall = mockQuery.mock.calls[0];
+
+      mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      await handlePostDeleted(mockPool, event, context);
+      const secondCall = mockQuery.mock.calls[1];
+
+      // The SQL shape and parameter order must be identical for both
+      // branches — only the rowCount changes.
+      expect(firstCall[0]).toBe(secondCall[0]);
+      expect(firstCall[1]).toEqual(secondCall[1]);
+    });
+
+    it("uses provided timestamp for deleted_at (not NOW()) for deterministic event-time semantics", async () => {
+      const fixedDate = new Date("2026-01-15T12:00:00.000Z");
+      const { event, context } = createMockPostDeletedEvent(1n, "GTEST123");
+      const customized = { ...context, timestamp: fixedDate };
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+      await handlePostDeleted(mockPool, event, customized);
+
+      // The first parameter must be the event timestamp, not the current
+      // server time, so the soft-delete reflects when the on-chain event
+      // happened (not when the indexer saw it).
+      expect(mockQuery.mock.calls[0][1][0]).toBe(fixedDate);
+    });
   });
 });


### PR DESCRIPTION
Closes the three GitHub issues assigned to Blaqkenny in a single PR.

Closes #129 — Mobile feed from real data
- Remove duplicate ALL_POSTS mock + broken module state in `apps/mobile/hooks/useFeed.ts`.
- New `apps/mobile/utils/indexerClient.ts` — thin fetch wrapper for `/api/posts` (listPosts) and `/api/posts/:id` (getPostById returns null for soft-deleted posts). Reads `EXPO_PUBLIC_INDEXER_URL`.
- `useFeed.ts` now paginates with limit/offset and surfaces `IndexerError` status codes via a `clampStatusCode` helper.
- `apps/mobile/app/post/[id].tsx` now fetches the single post from the indexer instead of the stale in-memory mock.

Closes #128 — In-app error handling for post submissions
- New `apps/mobile/hooks/useCreatePost.ts` — typed `submit()` wrapping the real `utils/createPost.ts` SDK pipeline.
- `utils/contractErrors.ts` adds `resolvePostSubmitError` mapping errors to 6 categories (USER_REJECTED, WALLET_DISCONNECTED, CONTENT_INVALID, UNAUTHORIZED, NETWORK, INTERNAL). USER_REJECTED patterns now cover “declined/cancelled” from Albedo/xBull/Lobster wallets.
- `apps/mobile/app/post/new.tsx` removes the 1.2 s `setTimeout` stub and surfaces categorized errors with a typed toast title.
- `ToastContext.showError` accepts an optional title parameter.

Closes #74 — Tests for soft-delete semantics
- `services/indexer/src/db.ts`: `getPost` now filters `deleted_at IS NULL` so the soft-delete contract is enforced at the read path.
- `services/indexer/src/handlers/__tests__/post.test.ts`: two new tests pin the soft-delete UPDATE shape and that the event timestamp (not NOW()) is used for `deleted_at`.

## New mobile tests
- `__tests__/useFeed.test.tsx` — pagination, deletion bus, error mapping.
- `__tests__/resolvePostSubmitError.test.ts` — every error category.

22 mobile tests + 8 indexer post tests pass.