### PR TITLE
Added support for multiple wallets

### DIFF
--- a/apps/web/src/lib/walletProviders.test.ts
+++ b/apps/web/src/lib/walletProviders.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveWalletProvider, type WalletProviderKind } from "./walletProviders";
+
+test("resolveWalletProvider falls back to the first supported provider", () => {
+  const provider = resolveWalletProvider(undefined, ["freighter", "walletconnect"]);
+  assert.equal(provider, "freighter");
+});
+
+test("resolveWalletProvider accepts an explicit provider", () => {
+  const provider = resolveWalletProvider("walletconnect", ["freighter", "walletconnect"]);
+  assert.equal(provider, "walletconnect");
+});
+
+test("resolveWalletProvider rejects unsupported providers", () => {
+  assert.throws(() => resolveWalletProvider("albedo" as WalletProviderKind, ["freighter", "walletconnect"]));
+});

--- a/apps/web/src/lib/walletProviders.ts
+++ b/apps/web/src/lib/walletProviders.ts
@@ -1,0 +1,39 @@
+export type WalletProviderKind = "freighter" | "walletconnect";
+
+export interface WalletProviderOption {
+  id: WalletProviderKind;
+  label: string;
+  description: string;
+}
+
+export const walletProviderOptions: WalletProviderOption[] = [
+  {
+    id: "freighter",
+    label: "Freighter",
+    description: "Browser extension for desktop and web signing",
+  },
+  {
+    id: "walletconnect",
+    label: "WalletConnect",
+    description: "Mobile and wallet apps via WalletConnect",
+  },
+];
+
+export function resolveWalletProvider(
+  provider: WalletProviderKind | null | undefined,
+  supported: WalletProviderKind[]
+): WalletProviderKind {
+  if (provider && supported.includes(provider)) {
+    return provider;
+  }
+
+  return supported[0] ?? "freighter";
+}
+
+export function getSupportedWalletProviders(
+  availability: Partial<Record<WalletProviderKind, boolean>>
+): WalletProviderKind[] {
+  return walletProviderOptions
+    .map((option) => option.id)
+    .filter((id) => availability[id] !== false);
+}


### PR DESCRIPTION
 Add support for multiple wallet providers
labels: enhancement, web, mobile
Allow users to connect with more than one supported wallet adapter
closes #248
closes #249

