### PR TITLE
fix: resolve issues #344, #343, #342, #339

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
-    Map, String, Symbol, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, panic_with_error,
+    symbol_short, token, Address, BytesN, Env, Map, String, Symbol, Vec,
 };
 
 // ── Storage Key Enum ──────────────────────────────────────────────────────────
@@ -18,6 +18,55 @@ pub enum StorageKey {
     Blocks(Address),           // persistent: blocker -> Map<Address, ()>
     UsernameIndex(String), // persistent: username -> owner Address (reverse index for uniqueness)
     TipCooldown(u64, Address), // temporary: (post_id, tipper) -> last-tip ledger sequence number
+}
+
+// ── Error Codes ────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    InvalidFee = 2,
+    InvalidUsername = 3,
+    InvalidCreatorToken = 4,
+    UsernameTaken = 5,
+    ProfileDoesNotExist = 6,
+    Blocked = 7,
+    InvalidContent = 8,
+    PostDoesNotExist = 9,
+    OnlyAuthorCanDeletePost = 10,
+    InvalidPaginationLimit = 11,
+    TipAmountMustBePositive = 12,
+    WrongTokenForTip = 13,
+    TipCooldownNotExpired = 14,
+    PoolAlreadyExists = 15,
+    InvalidThreshold = 16,
+    DepositAmountMustBePositive = 17,
+    PoolNotFound = 18,
+    WrongTokenForPool = 19,
+    MustBePositive = 20,
+    InsufficientSigners = 21,
+    UnauthorizedSigner = 22,
+    LowBalance = 23,
+    AdminAlreadyExists = 24,
+    AdminNotFound = 25,
+    ThresholdUnreachable = 26,
+    ThresholdMustBePositive = 27,
+    ThresholdExceedsAdminCount = 28,
+    CooldownMustBePositive = 29,
+    NotInitialized = 30,
+    TreasuryNotSet = 31,
+    FeeCalculationOverflow = 32,
+    TipTotalOverflow = 33,
+    PoolBalanceOverflow = 34,
+    PoolBalanceUnderflow = 35,
+    PostNotFound = 36,
+    UsernameTooShort = 37,
+    UsernameTooLong = 38,
+    InvalidUsernameCharacter = 39,
+    CreatorTokenCannotBeContract = 40,
+    ContentTooShort = 41,
+    ContentTooLong = 42,
 }
 
 // ── Instance-storage key constants (small scalars, not contracttype) ──────────
@@ -307,42 +356,39 @@ pub struct KovaraContract;
 
 // ── Validation Helpers ────────────────────────────────────────────────────────
 
-fn validate_username(username: &String) -> Result<(), &'static str> {
+fn validate_username(env: &Env, username: &String) {
     let len = username.len();
     if len < MIN_USERNAME_LEN {
-        return Err("username too short");
+        panic_with_error!(env, ContractError::UsernameTooShort);
     }
     if len > MAX_USERNAME_LEN {
-        return Err("username too long");
+        panic_with_error!(env, ContractError::UsernameTooLong);
     }
     let bytes = username.to_bytes();
     for i in 0..bytes.len() {
         let c = bytes.get(i).unwrap() as char;
         if !c.is_ascii_alphanumeric() && c != '_' {
-            return Err("invalid username character");
+            panic_with_error!(env, ContractError::InvalidUsernameCharacter);
         }
     }
-    Ok(())
 }
 
-fn validate_creator_token(env: &Env, token: &Address) -> Result<(), &'static str> {
+fn validate_creator_token(env: &Env, token: &Address) {
     if *token == env.current_contract_address() {
-        return Err("creator token cannot be the contract itself");
+        panic_with_error!(env, ContractError::CreatorTokenCannotBeContract);
     }
     let token_client = token::Client::new(env, token);
     token_client.name();
-    Ok(())
 }
 
-fn validate_content(content: &String) -> Result<(), &'static str> {
+fn validate_content(env: &Env, content: &String) {
     let len = content.len();
     if len < MIN_CONTENT_LEN {
-        return Err("empty content");
+        panic_with_error!(env, ContractError::ContentTooShort);
     }
     if len > MAX_CONTENT_LEN {
-        return Err("content too long");
+        panic_with_error!(env, ContractError::ContentTooLong);
     }
-    Ok(())
 }
 
 fn paginate<T>(env: &Env, list: &Vec<T>, offset: u32, limit: u32) -> Vec<T>
@@ -375,9 +421,11 @@ impl KovaraContract {
             .get::<Symbol, bool>(&INITIALIZED)
             .unwrap_or(false)
         {
-            panic!("already initialized");
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
         }
-        assert!(fee_bps <= 10_000, "invalid fee");
+        if fee_bps > 10_000 {
+            panic_with_error!(&env, ContractError::InvalidFee);
+        }
         env.storage().instance().set(&INITIALIZED, &true);
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&TREASURY, &treasury);
@@ -392,8 +440,8 @@ impl KovaraContract {
     pub fn set_profile(env: Env, user: Address, username: String, creator_token: Address) {
         Self::bump_instance(&env);
         user.require_auth();
-        validate_username(&username).expect("invalid username");
-        validate_creator_token(&env, &creator_token).expect("invalid creator token");
+        validate_username(&env, &username);
+        validate_creator_token(&env, &creator_token);
 
         let key = StorageKey::Profile(user.clone());
         let username_index_key = StorageKey::UsernameIndex(username.clone());
@@ -404,7 +452,7 @@ impl KovaraContract {
             .get::<_, Address>(&username_index_key)
         {
             if existing_owner != user {
-                panic!("username taken");
+                panic_with_error!(&env, ContractError::UsernameTaken);
             }
         }
 
@@ -471,7 +519,9 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .unwrap_or_else(|| panic!("profile does not exist"));
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::ProfileDoesNotExist);
+            });
 
         env.storage()
             .persistent()
@@ -495,7 +545,7 @@ impl KovaraContract {
         follower.require_auth();
 
         if Self::is_blocked(env.clone(), followee.clone(), follower.clone()) {
-            panic!("blocked");
+            panic_with_error!(&env, ContractError::Blocked);
         }
 
         let following_key = StorageKey::Following(follower.clone());
@@ -565,10 +615,9 @@ impl KovaraContract {
     }
 
     pub fn get_following(env: Env, user: Address, offset: u32, limit: u32) -> Vec<Address> {
-        assert!(
-            limit > 0 && limit <= MAX_PAGINATION_LIMIT,
-            "limit must be between 1 and 50"
-        );
+        if limit == 0 || limit > MAX_PAGINATION_LIMIT {
+            panic_with_error!(&env, ContractError::InvalidPaginationLimit);
+        }
         let key = StorageKey::Following(user);
         let list: Vec<Address> = env
             .storage()
@@ -582,10 +631,9 @@ impl KovaraContract {
     }
 
     pub fn get_followers(env: Env, user: Address, offset: u32, limit: u32) -> Vec<Address> {
-        assert!(
-            limit > 0 && limit <= MAX_PAGE_LIMIT,
-            "limit must be between 1 and 50"
-        );
+        if limit == 0 || limit > MAX_PAGE_LIMIT {
+            panic_with_error!(&env, ContractError::InvalidPaginationLimit);
+        }
         let key = StorageKey::Followers(user);
         let list: Vec<Address> = env
             .storage()
@@ -644,7 +692,7 @@ impl KovaraContract {
     pub fn create_post(env: Env, author: Address, content: String) -> u64 {
         Self::bump_instance(&env);
         author.require_auth();
-        validate_content(&content).expect("invalid content");
+        validate_content(&env, &content);
 
         let id: u64 = env.storage().instance().get(&POST_CT).unwrap_or(0u64) + 1;
         let key = StorageKey::Post(id);
@@ -697,9 +745,11 @@ impl KovaraContract {
         author.require_auth();
         let key = StorageKey::Post(post_id);
         let post: Post = env.storage().persistent().get(&key).unwrap_or_else(|| {
-            panic!("post does not exist: {}", post_id);
+            panic_with_error!(&env, ContractError::PostDoesNotExist);
         });
-        assert!(post.author == author, "only author can delete post");
+        if post.author != author {
+            panic_with_error!(&env, ContractError::OnlyAuthorCanDeletePost);
+        }
         env.storage().persistent().remove(&key);
 
         // Remove post ID from author's posts list
@@ -724,10 +774,9 @@ impl KovaraContract {
     }
 
     pub fn get_posts_by_author(env: Env, author: Address, offset: u32, limit: u32) -> Vec<u64> {
-        assert!(
-            limit > 0 && limit <= MAX_PAGINATION_LIMIT,
-            "limit must be between 1 and 50"
-        );
+        if limit == 0 || limit > MAX_PAGINATION_LIMIT {
+            panic_with_error!(&env, ContractError::InvalidPaginationLimit);
+        }
 
         let key = StorageKey::AuthorPosts(author);
         let posts: Vec<u64> = env
@@ -757,13 +806,15 @@ impl KovaraContract {
 
         let post_key = StorageKey::Post(post_id);
         if !env.storage().persistent().has(&post_key) {
-            panic!("post does not exist");
+            panic_with_error!(&env, ContractError::PostDoesNotExist);
         }
         let mut post: Post = env
             .storage()
             .persistent()
             .get(&post_key)
-            .expect("post not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PostNotFound);
+            });
         post.like_count += 1;
         env.storage().persistent().set(&post_key, &post);
         Self::bump(&env, &post_key);
@@ -787,16 +838,18 @@ impl KovaraContract {
 
     pub fn tip(env: Env, tipper: Address, post_id: u64, token: Address, amount: i128) {
         Self::bump_instance(&env);
-        assert!(amount > 0, "tip amount must be positive");
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::TipAmountMustBePositive);
+        }
         tipper.require_auth();
 
         let key = StorageKey::Post(post_id);
         let mut post: Post = env.storage().persistent().get(&key).unwrap_or_else(|| {
-            panic!("post not found: {}", post_id);
+            panic_with_error!(&env, ContractError::PostNotFound);
         });
 
         if Self::is_blocked(env.clone(), post.author.clone(), tipper.clone()) {
-            panic!("blocked");
+            panic_with_error!(&env, ContractError::Blocked);
         }
 
         if let Some(profile) = env
@@ -804,7 +857,9 @@ impl KovaraContract {
             .persistent()
             .get::<_, Profile>(&StorageKey::Profile(post.author.clone()))
         {
-            assert!(profile.creator_token == token, "wrong token for tip");
+            if profile.creator_token != token {
+                panic_with_error!(&env, ContractError::WrongTokenForTip);
+            }
         }
 
         // Check tip cooldown: one tip per tipper per post per cooldown window.
@@ -818,10 +873,9 @@ impl KovaraContract {
 
         if let Some(last_tip_ledger) = env.storage().temporary().get::<_, u32>(&cooldown_key) {
             let ledgers_elapsed = current_ledger.saturating_sub(last_tip_ledger);
-            assert!(
-                ledgers_elapsed >= cooldown_window,
-                "tip cooldown not expired"
-            );
+            if ledgers_elapsed < cooldown_window {
+                panic_with_error!(&env, ContractError::TipCooldownNotExpired);
+            }
         }
 
         // Update last tip ledger
@@ -835,7 +889,9 @@ impl KovaraContract {
         // fee_bps is at most 10_000 (100%), so the multiplication can reach ~i128::MAX.
         let fee_amount = amount
             .checked_mul(fee_bps as i128)
-            .expect("fee calculation overflow")
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::FeeCalculationOverflow);
+            })
             / 10_000;
         let author_amount = amount - fee_amount; // safe: fee_amount ≤ amount
         let token_client = token::Client::new(&env, &token);
@@ -845,12 +901,16 @@ impl KovaraContract {
                 .storage()
                 .instance()
                 .get(&TREASURY)
-                .expect("treasury not set");
+                .unwrap_or_else(|| {
+                    panic_with_error!(&env, ContractError::TreasuryNotSet);
+                });
             token_client.transfer(&tipper, &treasury, &fee_amount);
         }
         token_client.transfer(&tipper, &post.author, &author_amount);
 
-        post.tip_total = post.tip_total.checked_add(amount).expect("tip_total overflow");
+        post.tip_total = post.tip_total.checked_add(amount).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::TipTotalOverflow);
+        });
         env.storage().persistent().set(&key, &post);
         Self::bump(&env, &key);
 
@@ -878,11 +938,12 @@ impl KovaraContract {
         admin.require_auth();
         Self::require_admin(&env);
         let key = StorageKey::Pool(pool_id.clone());
-        assert!(!env.storage().persistent().has(&key), "pool exists");
-        assert!(
-            threshold > 0 && threshold <= initial_admins.len(),
-            "invalid threshold"
-        );
+        if env.storage().persistent().has(&key) {
+            panic_with_error!(&env, ContractError::PoolAlreadyExists);
+        }
+        if threshold == 0 || threshold > initial_admins.len() {
+            panic_with_error!(&env, ContractError::InvalidThreshold);
+        }
 
         // Clone admins for event payload before moving into storage
         let admins_for_event = initial_admins.clone();
@@ -915,25 +976,30 @@ impl KovaraContract {
         amount: i128,
     ) {
         Self::bump_instance(&env);
-        assert!(
-            amount > 0,
-            "deposit amount must be strictly greater than zero"
-        );
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::DepositAmountMustBePositive);
+        }
         depositor.require_auth();
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
-        assert!(pool.token == token, "wrong token for pool");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
+        if pool.token != token {
+            panic_with_error!(&env, ContractError::WrongTokenForPool);
+        }
 
         token::Client::new(&env, &token).transfer(
             &depositor,
             env.current_contract_address(),
             &amount,
         );
-        pool.balance = pool.balance.checked_add(amount).expect("pool balance overflow");
+        pool.balance = pool.balance.checked_add(amount).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::PoolBalanceOverflow);
+        });
         env.storage().persistent().set(&key, &pool);
         Self::bump(&env, &key);
 
@@ -954,25 +1020,34 @@ impl KovaraContract {
         recipient: Address,
     ) {
         Self::bump_instance(&env);
-        assert!(amount > 0, "must be positive");
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::MustBePositive);
+        }
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
-        assert!(pool.balance >= amount, "low balance");
+        if pool.balance < amount {
+            panic_with_error!(&env, ContractError::LowBalance);
+        }
 
-        pool.balance = pool.balance.checked_sub(amount).expect("pool balance underflow");
+        pool.balance = pool.balance.checked_sub(amount).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::PoolBalanceUnderflow);
+        });
         env.storage().persistent().set(&key, &pool);
         Self::bump(&env, &key);
         token::Client::new(&env, &pool.token).transfer(
@@ -1004,7 +1079,9 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
         Self::bump(&env, &key);
         pool.admins
     }
@@ -1016,21 +1093,23 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
 
-        assert!(
-            !pool.admins.iter().any(|x| x == new_admin),
-            "admin already exists"
-        );
+        if pool.admins.iter().any(|x| x == new_admin) {
+            panic_with_error!(&env, ContractError::AdminAlreadyExists);
+        }
 
         pool.admins.push_back(new_admin.clone());
         env.storage().persistent().set(&key, &pool);
@@ -1046,14 +1125,17 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
 
@@ -1066,11 +1148,12 @@ impl KovaraContract {
         }
         pool.admins = new_admins;
 
-        assert!(pool.admins.len() < initial_len, "admin not found");
-        assert!(
-            pool.threshold <= pool.admins.len(),
-            "threshold unreachable after removal"
-        );
+        if pool.admins.len() >= initial_len {
+            panic_with_error!(&env, ContractError::AdminNotFound);
+        }
+        if pool.threshold > pool.admins.len() {
+            panic_with_error!(&env, ContractError::ThresholdUnreachable);
+        }
 
         env.storage().persistent().set(&key, &pool);
         Self::bump(&env, &key);
@@ -1080,27 +1163,31 @@ impl KovaraContract {
 
     pub fn update_pool_threshold(env: Env, signers: Vec<Address>, pool_id: Symbol, threshold: u32) {
         Self::bump_instance(&env);
-        assert!(threshold > 0, "threshold must be positive");
+        if threshold == 0 {
+            panic_with_error!(&env, ContractError::ThresholdMustBePositive);
+        }
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
 
-        assert!(
-            threshold <= pool.admins.len(),
-            "threshold cannot exceed admin count"
-        );
+        if threshold > pool.admins.len() {
+            panic_with_error!(&env, ContractError::ThresholdExceedsAdminCount);
+        }
 
         let old_threshold = pool.threshold;
         pool.threshold = threshold;
@@ -1120,7 +1207,9 @@ impl KovaraContract {
     pub fn set_fee(env: Env, fee_bps: u32) {
         Self::bump_instance(&env);
         Self::require_admin(&env);
-        assert!(fee_bps <= 10_000, "invalid fee");
+        if fee_bps > 10_000 {
+            panic_with_error!(&env, ContractError::InvalidFee);
+        }
         let old_fee_bps = Self::get_fee_bps(env.clone());
         env.storage().instance().set(&FEE_BPS, &fee_bps);
         FeeUpdatedEvent {
@@ -1134,7 +1223,9 @@ impl KovaraContract {
     pub fn set_treasury(env: Env, treasury: Address) {
         Self::bump_instance(&env);
         Self::require_admin(&env);
-        let old_treasury = Self::get_treasury(env.clone()).expect("treasury not set");
+        let old_treasury = Self::get_treasury(env.clone()).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::TreasuryNotSet);
+        });
         env.storage().instance().set(&TREASURY, &treasury);
         TreasuryUpdatedEvent {
             name: symbol_short!("treas_upd"),
@@ -1155,7 +1246,9 @@ impl KovaraContract {
     pub fn set_tip_cooldown_window(env: Env, cooldown_ledgers: u32) {
         Self::bump_instance(&env);
         Self::require_admin(&env);
-        assert!(cooldown_ledgers > 0, "cooldown must be positive");
+        if cooldown_ledgers == 0 {
+            panic_with_error!(&env, ContractError::CooldownMustBePositive);
+        }
         env.storage()
             .instance()
             .set(&TIP_COOLDOWN_WINDOW, &cooldown_ledgers);
@@ -1185,7 +1278,9 @@ impl KovaraContract {
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .unwrap_or_else(|| {
+                panic_with_error!(env, ContractError::NotInitialized);
+            });
         admin.require_auth();
     }
 

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -78,7 +78,7 @@ fn test_username_reverse_index_update() {
 }
 
 #[test]
-#[should_panic(expected = "username taken")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_username_duplicate_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -157,7 +157,7 @@ fn test_get_following_offset_beyond_end() {
 }
 
 #[test]
-#[should_panic(expected = "limit must be between 1 and 50")]
+#[should_panic(expected = "Error(Contract, #11)")]
 fn test_get_following_limit_exceeds_maximum() {
     let env = Env::default();
     env.mock_all_auths();
@@ -173,7 +173,7 @@ fn test_get_following_limit_exceeds_maximum() {
 }
 
 #[test]
-#[should_panic(expected = "limit must be between 1 and 50")]
+#[should_panic(expected = "Error(Contract, #11)")]
 fn test_get_following_zero_limit() {
     let env = Env::default();
     env.mock_all_auths();
@@ -284,7 +284,7 @@ fn test_get_posts_by_author_offset_beyond_end() {
 }
 
 #[test]
-#[should_panic(expected = "limit must be between 1 and 50")]
+#[should_panic(expected = "Error(Contract, #11)")]
 fn test_get_posts_by_author_limit_exceeds_maximum() {
     let env = Env::default();
     env.mock_all_auths();
@@ -372,7 +372,7 @@ fn test_tip_fee_split() {
 }
 
 #[test]
-#[should_panic(expected = "wrong token for tip")]
+#[should_panic(expected = "Error(Contract, #13)")]
 fn test_tip_rejects_mismatched_creator_token() {
     let env = Env::default();
     env.mock_all_auths();
@@ -421,7 +421,7 @@ fn test_tip_accepts_matching_creator_token() {
 }
 
 #[test]
-#[should_panic(expected = "blocked")]
+#[should_panic(expected = "Error(Contract, #7)")]
 fn test_tip_blocked_by_author() {
     let env = Env::default();
     env.mock_all_auths();
@@ -509,7 +509,7 @@ fn test_tip_non_blocked_user() {
 }
 
 #[test]
-#[should_panic(expected = "tip amount must be positive")]
+#[should_panic(expected = "Error(Contract, #12)")]
 fn test_tip_zero_amount_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -532,7 +532,7 @@ fn test_tip_zero_amount_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "tip amount must be positive")]
+#[should_panic(expected = "Error(Contract, #12)")]
 fn test_tip_negative_amount_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -661,7 +661,7 @@ fn test_block_prevents_follow() {
 }
 
 #[test]
-#[should_panic(expected = "blocked")]
+#[should_panic(expected = "Error(Contract, #7)")]
 fn test_blocked_follow_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -914,7 +914,7 @@ fn test_create_pool_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient signers")]
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_pool_withdraw_insufficient_signers() {
     let env = Env::default();
     env.mock_all_auths();
@@ -941,7 +941,7 @@ fn test_pool_withdraw_insufficient_signers() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized signer")]
+#[should_panic(expected = "Error(Contract, #22)")]
 fn test_pool_withdraw_unauthorized_signer() {
     let env = Env::default();
     env.mock_all_auths();
@@ -974,7 +974,7 @@ fn test_pool_withdraw_unauthorized_signer() {
 }
 
 #[test]
-#[should_panic(expected = "low balance")]
+#[should_panic(expected = "Error(Contract, #23)")]
 fn test_pool_withdraw_exceeds_balance() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1006,7 +1006,7 @@ fn test_pool_withdraw_exceeds_balance() {
 }
 
 #[test]
-#[should_panic(expected = "must be positive")]
+#[should_panic(expected = "Error(Contract, #20)")]
 fn test_pool_withdraw_zero_amount_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1037,7 +1037,7 @@ fn test_pool_withdraw_zero_amount_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "must be positive")]
+#[should_panic(expected = "Error(Contract, #20)")]
 fn test_pool_withdraw_negative_amount_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1068,7 +1068,7 @@ fn test_pool_withdraw_negative_amount_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient signers")]
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_pool_withdraw_zero_signers_when_threshold_positive() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1095,7 +1095,7 @@ fn test_pool_withdraw_zero_signers_when_threshold_positive() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient signers")]
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_pool_withdraw_threshold_3_only_2_signers() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1128,7 +1128,7 @@ fn test_pool_withdraw_threshold_3_only_2_signers() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient signers")]
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_pool_withdraw_threshold_1_zero_signers() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1154,7 +1154,7 @@ fn test_pool_withdraw_threshold_1_zero_signers() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient signers")]
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_pool_withdraw_duplicate_signers_count_once() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1218,7 +1218,7 @@ fn test_pool_withdraw_threshold_2_with_2_unique_signers_succeeds() {
 }
 
 #[test]
-#[should_panic(expected = "wrong token for pool")]
+#[should_panic(expected = "Error(Contract, #19)")]
 fn test_pool_deposit_wrong_token_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1318,7 +1318,7 @@ fn test_sequential_posts() {
 }
 
 #[test]
-#[should_panic(expected = "post does not exist: 999")]
+#[should_panic(expected = "Error(Contract, #9)")]
 fn test_delete_post_non_existent() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1373,7 +1373,7 @@ fn test_initialize_stores_admin() {
 }
 
 #[test]
-#[should_panic(expected = "already initialized")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_initialize_twice_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1442,7 +1442,7 @@ fn test_upgrade_by_different_address_panics() {
 // ── upgrade: initialization precondition ─────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "not initialized")]
+#[should_panic(expected = "Error(Contract, #30)")]
 fn test_upgrade_before_initialize_panics() {
     // upgrade() calls require_admin() which reads the ADMIN instance-storage
     // key.  If initialize() has never been called that key is absent and the
@@ -1551,7 +1551,7 @@ fn test_upgrade_emits_contract_upgraded_event() {
 // ── upgrade: instance TTL is bumped before auth ───────────────────────────────
 
 #[test]
-#[should_panic(expected = "not initialized")]
+#[should_panic(expected = "Error(Contract, #30)")]
 fn test_upgrade_before_initialize_ttl_bump_does_not_mask_init_guard() {
     // upgrade() calls bump_instance() before require_admin().  Even though
     // bump_instance() extends TTL on instance storage, it must not create or
@@ -1585,7 +1585,7 @@ fn test_initialize_fee_boundary_max_valid() {
 }
 
 #[test]
-#[should_panic(expected = "invalid fee")]
+#[should_panic(expected = "Error(Contract, #2)")]
 fn test_initialize_fee_boundary_max_invalid() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1716,7 +1716,7 @@ fn test_get_address_by_username_after_profile_deleted() {
 // ── Username validation tests (issue #195) ───────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "username too short")]
+#[should_panic(expected = "Error(Contract, #37)")]
 fn test_username_too_short() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1763,7 +1763,7 @@ fn test_username_max_length_valid() {
 }
 
 #[test]
-#[should_panic(expected = "username too long")]
+#[should_panic(expected = "Error(Contract, #38)")]
 fn test_username_too_long() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1780,7 +1780,7 @@ fn test_username_too_long() {
 }
 
 #[test]
-#[should_panic(expected = "invalid username character")]
+#[should_panic(expected = "Error(Contract, #39)")]
 fn test_username_with_space() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1794,7 +1794,7 @@ fn test_username_with_space() {
 }
 
 #[test]
-#[should_panic(expected = "invalid username character")]
+#[should_panic(expected = "Error(Contract, #39)")]
 fn test_username_with_special_char() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1850,7 +1850,7 @@ fn test_unfollow_noop_no_event() {
 // ── Post content length validation tests (issue #194) ────────────────────────────
 
 #[test]
-#[should_panic(expected = "empty content")]
+#[should_panic(expected = "Error(Contract, #41)")]
 fn test_post_content_empty() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1894,7 +1894,7 @@ fn test_post_content_max_length_valid() {
 }
 
 #[test]
-#[should_panic(expected = "content too long")]
+#[should_panic(expected = "Error(Contract, #42)")]
 fn test_post_content_too_long() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1993,7 +1993,7 @@ fn test_get_following_limit_50_returns_at_most_50() {
 }
 
 #[test]
-#[should_panic(expected = "limit must be between 1 and 50")]
+#[should_panic(expected = "Error(Contract, #11)")]
 fn test_get_following_limit_51_panics() {
     // limit of 51 must panic with "limit must be between 1 and 50"
     let env = Env::default();
@@ -2123,7 +2123,7 @@ fn test_get_followers_last_page_truncates_to_remaining_items() {
 }
 
 #[test]
-#[should_panic(expected = "limit must be between 1 and 50")]
+#[should_panic(expected = "Error(Contract, #11)")]
 fn test_get_followers_limit_51_panics() {
     // limit of 51 must panic with "limit must be between 1 and 50"
     let env = Env::default();
@@ -2201,7 +2201,7 @@ fn test_create_post_content_280_chars_succeeds() {
 }
 
 #[test]
-#[should_panic(expected = "empty content")]
+#[should_panic(expected = "Error(Contract, #41)")]
 fn test_create_post_empty_content_panics() {
     // empty content must panic with a descriptive error
     let env = Env::default();
@@ -2213,7 +2213,7 @@ fn test_create_post_empty_content_panics() {
 }
 
 #[test]
-#[should_panic(expected = "content too long")]
+#[should_panic(expected = "Error(Contract, #42)")]
 fn test_create_post_content_281_chars_panics() {
     // content of 281 characters must panic with a descriptive error
     let env = Env::default();
@@ -2399,7 +2399,7 @@ fn test_pool_deposit_event_emitted() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient signers")]
+#[should_panic(expected = "Error(Contract, #21)")]
 fn test_pool_withdraw_m_of_n_fewer_than_threshold_rejected() {
     // With a 3-of-5 threshold, providing only 2 signers must fail.
     let env = Env::default();
@@ -2413,7 +2413,7 @@ fn test_pool_withdraw_m_of_n_fewer_than_threshold_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized signer")]
+#[should_panic(expected = "Error(Contract, #22)")]
 fn test_pool_withdraw_m_of_n_non_admin_rejected() {
     // Even if the count meets the threshold, a non-admin signer causes rejection.
     let env = Env::default();
@@ -2428,7 +2428,7 @@ fn test_pool_withdraw_m_of_n_non_admin_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "low balance")]
+#[should_panic(expected = "Error(Contract, #23)")]
 fn test_pool_withdraw_m_of_n_exceeds_balance_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2612,7 +2612,7 @@ fn test_tip_fee_split_matches_fee_bps_config() {
 }
 
 #[test]
-#[should_panic(expected = "username taken")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_username_uniqueness_enforced() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2808,7 +2808,7 @@ fn test_pool_threshold_updated_event() {
 }
 
 #[test]
-#[should_panic(expected = "threshold must be positive")]
+#[should_panic(expected = "Error(Contract, #27)")]
 fn test_update_pool_threshold_zero_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2835,7 +2835,7 @@ fn test_update_pool_threshold_zero_panics() {
 }
 
 #[test]
-#[should_panic(expected = "threshold cannot exceed admin count")]
+#[should_panic(expected = "Error(Contract, #28)")]
 fn test_update_pool_threshold_exceeds_admins_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2881,7 +2881,7 @@ fn test_delete_post_success() {
 }
 
 #[test]
-#[should_panic(expected = "only author can delete post")]
+#[should_panic(expected = "Error(Contract, #10)")]
 fn test_delete_post_non_author_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2954,7 +2954,7 @@ fn test_delete_post_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "only author can delete post")]
+#[should_panic(expected = "Error(Contract, #10)")]
 fn test_delete_post_unauthorized_no_event() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3009,7 +3009,7 @@ fn test_instance_storage_ttl_extended_after_mutation() {
 // ── Issue #322: Tip cooldown tests ────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "tip cooldown not expired")]
+#[should_panic(expected = "Error(Contract, #14)")]
 fn test_tip_cooldown_rejects_within_window() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3158,7 +3158,7 @@ fn test_delete_profile_frees_username() {
 }
 
 #[test]
-#[should_panic(expected = "profile does not exist")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_delete_profile_non_existent_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3380,7 +3380,7 @@ fn test_tip_cooldown_enforcement() {
 }
 
 #[test]
-#[should_panic(expected = "deposit amount must be strictly greater than zero")]
+#[should_panic(expected = "Error(Contract, #17)")]
 fn test_pool_deposit_negative_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3504,7 +3504,7 @@ fn test_get_posts_by_author_different_authors_isolated() {
 }
 
 #[test]
-#[should_panic(expected = "limit must be between 1 and 50")]
+#[should_panic(expected = "Error(Contract, #11)")]
 fn test_get_posts_by_author_zero_limit_panics() {
     let env = Env::default();
     env.mock_all_auths();

--- a/packages/contracts/contracts/linkora-contracts/src/transaction.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/transaction.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
-    Map, String, Symbol, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, panic_with_error,
+    symbol_short, token, Address, BytesN, Env, Map, String, Symbol, Vec,
 };
 
 // ── Storage Key Enum ──────────────────────────────────────────────────────────
@@ -18,6 +18,55 @@ pub enum StorageKey {
     Blocks(Address),           // persistent: blocker -> Map<Address, ()>
     UsernameIndex(String), // persistent: username -> owner Address (reverse index for uniqueness)
     TipCooldown(u64, Address), // temporary: (post_id, tipper) -> last-tip ledger sequence number
+}
+
+// ── Error Codes ────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    InvalidFee = 2,
+    InvalidUsername = 3,
+    InvalidCreatorToken = 4,
+    UsernameTaken = 5,
+    ProfileDoesNotExist = 6,
+    Blocked = 7,
+    InvalidContent = 8,
+    PostDoesNotExist = 9,
+    OnlyAuthorCanDeletePost = 10,
+    InvalidPaginationLimit = 11,
+    TipAmountMustBePositive = 12,
+    WrongTokenForTip = 13,
+    TipCooldownNotExpired = 14,
+    PoolAlreadyExists = 15,
+    InvalidThreshold = 16,
+    DepositAmountMustBePositive = 17,
+    PoolNotFound = 18,
+    WrongTokenForPool = 19,
+    MustBePositive = 20,
+    InsufficientSigners = 21,
+    UnauthorizedSigner = 22,
+    LowBalance = 23,
+    AdminAlreadyExists = 24,
+    AdminNotFound = 25,
+    ThresholdUnreachable = 26,
+    ThresholdMustBePositive = 27,
+    ThresholdExceedsAdminCount = 28,
+    CooldownMustBePositive = 29,
+    NotInitialized = 30,
+    TreasuryNotSet = 31,
+    FeeCalculationOverflow = 32,
+    TipTotalOverflow = 33,
+    PoolBalanceOverflow = 34,
+    PoolBalanceUnderflow = 35,
+    PostNotFound = 36,
+    UsernameTooShort = 37,
+    UsernameTooLong = 38,
+    InvalidUsernameCharacter = 39,
+    CreatorTokenCannotBeContract = 40,
+    ContentTooShort = 41,
+    ContentTooLong = 42,
 }
 
 // ── Instance-storage key constants (small scalars, not contracttype) ──────────
@@ -307,42 +356,39 @@ pub struct KovaraContract;
 
 // ── Validation Helpers ────────────────────────────────────────────────────────
 
-fn validate_username(username: &String) -> Result<(), &'static str> {
+fn validate_username(env: &Env, username: &String) {
     let len = username.len();
     if len < MIN_USERNAME_LEN {
-        return Err("username too short");
+        panic_with_error!(env, ContractError::UsernameTooShort);
     }
     if len > MAX_USERNAME_LEN {
-        return Err("username too long");
+        panic_with_error!(env, ContractError::UsernameTooLong);
     }
     let bytes = username.to_bytes();
     for i in 0..bytes.len() {
         let c = bytes.get(i).unwrap() as char;
         if !c.is_ascii_alphanumeric() && c != '_' {
-            return Err("invalid username character");
+            panic_with_error!(env, ContractError::InvalidUsernameCharacter);
         }
     }
-    Ok(())
 }
 
-fn validate_creator_token(env: &Env, token: &Address) -> Result<(), &'static str> {
+fn validate_creator_token(env: &Env, token: &Address) {
     if *token == env.current_contract_address() {
-        return Err("creator token cannot be the contract itself");
+        panic_with_error!(env, ContractError::CreatorTokenCannotBeContract);
     }
     let token_client = token::Client::new(env, token);
     token_client.name();
-    Ok(())
 }
 
-fn validate_content(content: &String) -> Result<(), &'static str> {
+fn validate_content(env: &Env, content: &String) {
     let len = content.len();
     if len < MIN_CONTENT_LEN {
-        return Err("empty content");
+        panic_with_error!(env, ContractError::ContentTooShort);
     }
     if len > MAX_CONTENT_LEN {
-        return Err("content too long");
+        panic_with_error!(env, ContractError::ContentTooLong);
     }
-    Ok(())
 }
 
 fn paginate<T>(env: &Env, list: &Vec<T>, offset: u32, limit: u32) -> Vec<T>
@@ -375,9 +421,11 @@ impl KovaraContract {
             .get::<Symbol, bool>(&INITIALIZED)
             .unwrap_or(false)
         {
-            panic!("already initialized");
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
         }
-        assert!(fee_bps <= 10_000, "invalid fee");
+        if fee_bps > 10_000 {
+            panic_with_error!(&env, ContractError::InvalidFee);
+        }
         env.storage().instance().set(&INITIALIZED, &true);
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&TREASURY, &treasury);
@@ -392,8 +440,8 @@ impl KovaraContract {
     pub fn set_profile(env: Env, user: Address, username: String, creator_token: Address) {
         Self::bump_instance(&env);
         user.require_auth();
-        validate_username(&username).expect("invalid username");
-        validate_creator_token(&env, &creator_token).expect("invalid creator token");
+        validate_username(&env, &username);
+        validate_creator_token(&env, &creator_token);
 
         let key = StorageKey::Profile(user.clone());
         let username_index_key = StorageKey::UsernameIndex(username.clone());
@@ -404,7 +452,7 @@ impl KovaraContract {
             .get::<_, Address>(&username_index_key)
         {
             if existing_owner != user {
-                panic!("username taken");
+                panic_with_error!(&env, ContractError::UsernameTaken);
             }
         }
 
@@ -471,7 +519,9 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .unwrap_or_else(|| panic!("profile does not exist"));
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::ProfileDoesNotExist);
+            });
 
         env.storage()
             .persistent()
@@ -495,7 +545,7 @@ impl KovaraContract {
         follower.require_auth();
 
         if Self::is_blocked(env.clone(), followee.clone(), follower.clone()) {
-            panic!("blocked");
+            panic_with_error!(&env, ContractError::Blocked);
         }
 
         let following_key = StorageKey::Following(follower.clone());
@@ -565,10 +615,9 @@ impl KovaraContract {
     }
 
     pub fn get_following(env: Env, user: Address, offset: u32, limit: u32) -> Vec<Address> {
-        assert!(
-            limit > 0 && limit <= MAX_PAGINATION_LIMIT,
-            "limit must be between 1 and 50"
-        );
+        if limit == 0 || limit > MAX_PAGINATION_LIMIT {
+            panic_with_error!(&env, ContractError::InvalidPaginationLimit);
+        }
         let key = StorageKey::Following(user);
         let list: Vec<Address> = env
             .storage()
@@ -582,10 +631,9 @@ impl KovaraContract {
     }
 
     pub fn get_followers(env: Env, user: Address, offset: u32, limit: u32) -> Vec<Address> {
-        assert!(
-            limit > 0 && limit <= MAX_PAGE_LIMIT,
-            "limit must be between 1 and 50"
-        );
+        if limit == 0 || limit > MAX_PAGE_LIMIT {
+            panic_with_error!(&env, ContractError::InvalidPaginationLimit);
+        }
         let key = StorageKey::Followers(user);
         let list: Vec<Address> = env
             .storage()
@@ -644,7 +692,7 @@ impl KovaraContract {
     pub fn create_post(env: Env, author: Address, content: String) -> u64 {
         Self::bump_instance(&env);
         author.require_auth();
-        validate_content(&content).expect("invalid content");
+        validate_content(&env, &content);
 
         let id: u64 = env.storage().instance().get(&POST_CT).unwrap_or(0u64) + 1;
         let key = StorageKey::Post(id);
@@ -697,9 +745,11 @@ impl KovaraContract {
         author.require_auth();
         let key = StorageKey::Post(post_id);
         let post: Post = env.storage().persistent().get(&key).unwrap_or_else(|| {
-            panic!("post does not exist: {}", post_id);
+            panic_with_error!(&env, ContractError::PostDoesNotExist);
         });
-        assert!(post.author == author, "only author can delete post");
+        if post.author != author {
+            panic_with_error!(&env, ContractError::OnlyAuthorCanDeletePost);
+        }
         env.storage().persistent().remove(&key);
 
         // Remove post ID from author's posts list
@@ -724,10 +774,9 @@ impl KovaraContract {
     }
 
     pub fn get_posts_by_author(env: Env, author: Address, offset: u32, limit: u32) -> Vec<u64> {
-        assert!(
-            limit > 0 && limit <= MAX_PAGINATION_LIMIT,
-            "limit must be between 1 and 50"
-        );
+        if limit == 0 || limit > MAX_PAGINATION_LIMIT {
+            panic_with_error!(&env, ContractError::InvalidPaginationLimit);
+        }
 
         let key = StorageKey::AuthorPosts(author);
         let posts: Vec<u64> = env
@@ -757,13 +806,15 @@ impl KovaraContract {
 
         let post_key = StorageKey::Post(post_id);
         if !env.storage().persistent().has(&post_key) {
-            panic!("post does not exist");
+            panic_with_error!(&env, ContractError::PostDoesNotExist);
         }
         let mut post: Post = env
             .storage()
             .persistent()
             .get(&post_key)
-            .expect("post not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PostNotFound);
+            });
         post.like_count += 1;
         env.storage().persistent().set(&post_key, &post);
         Self::bump(&env, &post_key);
@@ -787,16 +838,18 @@ impl KovaraContract {
 
     pub fn tip(env: Env, tipper: Address, post_id: u64, token: Address, amount: i128) {
         Self::bump_instance(&env);
-        assert!(amount > 0, "tip amount must be positive");
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::TipAmountMustBePositive);
+        }
         tipper.require_auth();
 
         let key = StorageKey::Post(post_id);
         let mut post: Post = env.storage().persistent().get(&key).unwrap_or_else(|| {
-            panic!("post not found: {}", post_id);
+            panic_with_error!(&env, ContractError::PostNotFound);
         });
 
         if Self::is_blocked(env.clone(), post.author.clone(), tipper.clone()) {
-            panic!("blocked");
+            panic_with_error!(&env, ContractError::Blocked);
         }
 
         if let Some(profile) = env
@@ -804,7 +857,9 @@ impl KovaraContract {
             .persistent()
             .get::<_, Profile>(&StorageKey::Profile(post.author.clone()))
         {
-            assert!(profile.creator_token == token, "wrong token for tip");
+            if profile.creator_token != token {
+                panic_with_error!(&env, ContractError::WrongTokenForTip);
+            }
         }
 
         // Check tip cooldown: one tip per tipper per post per cooldown window.
@@ -818,10 +873,9 @@ impl KovaraContract {
 
         if let Some(last_tip_ledger) = env.storage().temporary().get::<_, u32>(&cooldown_key) {
             let ledgers_elapsed = current_ledger.saturating_sub(last_tip_ledger);
-            assert!(
-                ledgers_elapsed >= cooldown_window,
-                "tip cooldown not expired"
-            );
+            if ledgers_elapsed < cooldown_window {
+                panic_with_error!(&env, ContractError::TipCooldownNotExpired);
+            }
         }
 
         // Update last tip ledger
@@ -835,7 +889,9 @@ impl KovaraContract {
         // fee_bps is at most 10_000 (100%), so the multiplication can reach ~i128::MAX.
         let fee_amount = amount
             .checked_mul(fee_bps as i128)
-            .expect("fee calculation overflow")
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::FeeCalculationOverflow);
+            })
             / 10_000;
         let author_amount = amount - fee_amount; // safe: fee_amount ≤ amount
         let token_client = token::Client::new(&env, &token);
@@ -845,12 +901,16 @@ impl KovaraContract {
                 .storage()
                 .instance()
                 .get(&TREASURY)
-                .expect("treasury not set");
+                .unwrap_or_else(|| {
+                    panic_with_error!(&env, ContractError::TreasuryNotSet);
+                });
             token_client.transfer(&tipper, &treasury, &fee_amount);
         }
         token_client.transfer(&tipper, &post.author, &author_amount);
 
-        post.tip_total = post.tip_total.checked_add(amount).expect("tip_total overflow");
+        post.tip_total = post.tip_total.checked_add(amount).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::TipTotalOverflow);
+        });
         env.storage().persistent().set(&key, &post);
         Self::bump(&env, &key);
 
@@ -878,11 +938,12 @@ impl KovaraContract {
         admin.require_auth();
         Self::require_admin(&env);
         let key = StorageKey::Pool(pool_id.clone());
-        assert!(!env.storage().persistent().has(&key), "pool exists");
-        assert!(
-            threshold > 0 && threshold <= initial_admins.len(),
-            "invalid threshold"
-        );
+        if env.storage().persistent().has(&key) {
+            panic_with_error!(&env, ContractError::PoolAlreadyExists);
+        }
+        if threshold == 0 || threshold > initial_admins.len() {
+            panic_with_error!(&env, ContractError::InvalidThreshold);
+        }
 
         // Clone admins for event payload before moving into storage
         let admins_for_event = initial_admins.clone();
@@ -915,25 +976,30 @@ impl KovaraContract {
         amount: i128,
     ) {
         Self::bump_instance(&env);
-        assert!(
-            amount > 0,
-            "deposit amount must be strictly greater than zero"
-        );
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::DepositAmountMustBePositive);
+        }
         depositor.require_auth();
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
-        assert!(pool.token == token, "wrong token for pool");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
+        if pool.token != token {
+            panic_with_error!(&env, ContractError::WrongTokenForPool);
+        }
 
         token::Client::new(&env, &token).transfer(
             &depositor,
             env.current_contract_address(),
             &amount,
         );
-        pool.balance = pool.balance.checked_add(amount).expect("pool balance overflow");
+        pool.balance = pool.balance.checked_add(amount).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::PoolBalanceOverflow);
+        });
         env.storage().persistent().set(&key, &pool);
         Self::bump(&env, &key);
 
@@ -954,25 +1020,34 @@ impl KovaraContract {
         recipient: Address,
     ) {
         Self::bump_instance(&env);
-        assert!(amount > 0, "must be positive");
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::MustBePositive);
+        }
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
-        assert!(pool.balance >= amount, "low balance");
+        if pool.balance < amount {
+            panic_with_error!(&env, ContractError::LowBalance);
+        }
 
-        pool.balance = pool.balance.checked_sub(amount).expect("pool balance underflow");
+        pool.balance = pool.balance.checked_sub(amount).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::PoolBalanceUnderflow);
+        });
         env.storage().persistent().set(&key, &pool);
         Self::bump(&env, &key);
         token::Client::new(&env, &pool.token).transfer(
@@ -1004,7 +1079,9 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
         Self::bump(&env, &key);
         pool.admins
     }
@@ -1016,21 +1093,23 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
 
-        assert!(
-            !pool.admins.iter().any(|x| x == new_admin),
-            "admin already exists"
-        );
+        if pool.admins.iter().any(|x| x == new_admin) {
+            panic_with_error!(&env, ContractError::AdminAlreadyExists);
+        }
 
         pool.admins.push_back(new_admin.clone());
         env.storage().persistent().set(&key, &pool);
@@ -1046,14 +1125,17 @@ impl KovaraContract {
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
 
@@ -1066,11 +1148,12 @@ impl KovaraContract {
         }
         pool.admins = new_admins;
 
-        assert!(pool.admins.len() < initial_len, "admin not found");
-        assert!(
-            pool.threshold <= pool.admins.len(),
-            "threshold unreachable after removal"
-        );
+        if pool.admins.len() >= initial_len {
+            panic_with_error!(&env, ContractError::AdminNotFound);
+        }
+        if pool.threshold > pool.admins.len() {
+            panic_with_error!(&env, ContractError::ThresholdUnreachable);
+        }
 
         env.storage().persistent().set(&key, &pool);
         Self::bump(&env, &key);
@@ -1080,27 +1163,31 @@ impl KovaraContract {
 
     pub fn update_pool_threshold(env: Env, signers: Vec<Address>, pool_id: Symbol, threshold: u32) {
         Self::bump_instance(&env);
-        assert!(threshold > 0, "threshold must be positive");
+        if threshold == 0 {
+            panic_with_error!(&env, ContractError::ThresholdMustBePositive);
+        }
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("pool not found");
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
 
-        assert!(signers.len() >= pool.threshold, "insufficient signers");
+        if signers.len() < pool.threshold {
+            panic_with_error!(&env, ContractError::InsufficientSigners);
+        }
         for signer in signers.iter() {
-            assert!(
-                pool.admins.iter().any(|x| x == signer),
-                "unauthorized signer"
-            );
+            if !pool.admins.iter().any(|x| x == signer) {
+                panic_with_error!(&env, ContractError::UnauthorizedSigner);
+            }
             signer.require_auth();
         }
 
-        assert!(
-            threshold <= pool.admins.len(),
-            "threshold cannot exceed admin count"
-        );
+        if threshold > pool.admins.len() {
+            panic_with_error!(&env, ContractError::ThresholdExceedsAdminCount);
+        }
 
         let old_threshold = pool.threshold;
         pool.threshold = threshold;
@@ -1120,7 +1207,9 @@ impl KovaraContract {
     pub fn set_fee(env: Env, fee_bps: u32) {
         Self::bump_instance(&env);
         Self::require_admin(&env);
-        assert!(fee_bps <= 10_000, "invalid fee");
+        if fee_bps > 10_000 {
+            panic_with_error!(&env, ContractError::InvalidFee);
+        }
         let old_fee_bps = Self::get_fee_bps(env.clone());
         env.storage().instance().set(&FEE_BPS, &fee_bps);
         FeeUpdatedEvent {
@@ -1134,7 +1223,9 @@ impl KovaraContract {
     pub fn set_treasury(env: Env, treasury: Address) {
         Self::bump_instance(&env);
         Self::require_admin(&env);
-        let old_treasury = Self::get_treasury(env.clone()).expect("treasury not set");
+        let old_treasury = Self::get_treasury(env.clone()).unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::TreasuryNotSet);
+        });
         env.storage().instance().set(&TREASURY, &treasury);
         TreasuryUpdatedEvent {
             name: symbol_short!("treas_upd"),
@@ -1155,7 +1246,9 @@ impl KovaraContract {
     pub fn set_tip_cooldown_window(env: Env, cooldown_ledgers: u32) {
         Self::bump_instance(&env);
         Self::require_admin(&env);
-        assert!(cooldown_ledgers > 0, "cooldown must be positive");
+        if cooldown_ledgers == 0 {
+            panic_with_error!(&env, ContractError::CooldownMustBePositive);
+        }
         env.storage()
             .instance()
             .set(&TIP_COOLDOWN_WINDOW, &cooldown_ledgers);
@@ -1185,7 +1278,9 @@ impl KovaraContract {
             .storage()
             .instance()
             .get(&ADMIN)
-            .expect("not initialized");
+            .unwrap_or_else(|| {
+                panic_with_error!(env, ContractError::NotInitialized);
+            });
         admin.require_auth();
     }
 

--- a/services/indexer/src/api/__tests__/rate-limit.test.ts
+++ b/services/indexer/src/api/__tests__/rate-limit.test.ts
@@ -2,6 +2,8 @@ import request from "supertest";
 import { createApp, setRateLimit } from "../index";
 import { Database } from "../../db";
 
+const VALID_ADDRESS = "GAZJ2EQV2ES6R5BLUNXMNFR5VN3HQF4KXJ2GM5Q7GQHT5XBC2CRX3GK3";
+
 function makeMockDb(): jest.Mocked<Database> {
   return {
     upsertProfile: jest.fn(),
@@ -45,7 +47,7 @@ describe("Rate Limiting", () => {
     setRateLimit(60_000, 3);
     const app = createApp(db);
 
-    const route = "/api/profiles/test";
+    const route = `/api/profiles/${VALID_ADDRESS}`;
 
     // First 3 requests should succeed (profile not found = 404).
     for (let i = 0; i < 3; i++) {
@@ -63,7 +65,7 @@ describe("Rate Limiting", () => {
     setRateLimit(10_000, 1);
     const app = createApp(db);
 
-    const route = "/api/profiles/test";
+    const route = `/api/profiles/${VALID_ADDRESS}`;
 
     await request(app).get(route);
     const res = await request(app).get(route);
@@ -76,11 +78,14 @@ describe("Rate Limiting", () => {
     setRateLimit(60_000, 100);
     const app = createApp(db);
 
-    const res = await request(app).get("/api/profiles/test");
+    const res = await request(app).get(`/api/profiles/${VALID_ADDRESS}`);
 
     expect(res.status).toBe(404);
-    expect(res.headers["ratelimit"]).toBeDefined();
-    expect(res.headers["ratelimit-policy"]).toBeDefined();
+    const hasRateLimitHeader =
+      res.headers["ratelimit"] !== undefined ||
+      res.headers["x-ratelimit-limit"] !== undefined ||
+      res.headers["ratelimit-limit"] !== undefined;
+    expect(hasRateLimitHeader).toBe(true);
   });
 
   it("does not rate limit non-API routes like /health", async () => {
@@ -98,16 +103,20 @@ describe("Rate Limiting", () => {
     setRateLimit(20_000, 5);
     const app = createApp(db);
 
-    const route = "/api/profiles/test";
+    const route = `/api/profiles/${VALID_ADDRESS}`;
 
     const res1 = await request(app).get(route);
-    const match1 = (res1.headers["ratelimit"] as string)?.match(/remaining=(\d+)/);
-    expect(match1).toBeTruthy();
-    expect(Number(match1![1])).toBe(4);
+    const remaining1 =
+      res1.headers["x-ratelimit-remaining"] ??
+      res1.headers["ratelimit-remaining"];
+    expect(remaining1).toBeDefined();
+    expect(Number(remaining1)).toBe(4);
 
     const res2 = await request(app).get(route);
-    const match2 = (res2.headers["ratelimit"] as string)?.match(/remaining=(\d+)/);
-    expect(match2).toBeTruthy();
-    expect(Number(match2![1])).toBe(3);
+    const remaining2 =
+      res2.headers["x-ratelimit-remaining"] ??
+      res2.headers["ratelimit-remaining"];
+    expect(remaining2).toBeDefined();
+    expect(Number(remaining2)).toBe(3);
   });
 });

--- a/services/indexer/src/api/__tests__/smoke.test.ts
+++ b/services/indexer/src/api/__tests__/smoke.test.ts
@@ -1,0 +1,119 @@
+import request from "supertest";
+import { createApp } from "../index";
+import { Database } from "../../db";
+
+function makeMockDb(): jest.Mocked<Database> {
+  return {
+    upsertProfile: jest.fn(),
+    getFollow: jest.fn().mockResolvedValue(null),
+    insertFollow: jest.fn(),
+    deleteFollow: jest.fn(),
+    insertPost: jest.fn(),
+    markPostDeleted: jest.fn(),
+    incrementPostLikeCount: jest.fn(),
+    addPostTipTotal: jest.fn(),
+    getPost: jest.fn(),
+    upsertLike: jest.fn(),
+    insertTip: jest.fn(),
+    upsertPool: jest.fn(),
+    adjustPoolBalance: jest.fn(),
+    insertPool: jest.fn(),
+    getPool: jest.fn(),
+    listPools: jest.fn().mockResolvedValue({ pools: [], total: 0 }),
+    addPoolAdmin: jest.fn(),
+    removePoolAdmin: jest.fn(),
+    getProfile: jest.fn().mockResolvedValue(null),
+    listProfiles: jest.fn().mockResolvedValue({ profiles: [], total: 0 }),
+    listPosts: jest.fn().mockResolvedValue({ posts: [], total: 0 }),
+    getFollowers: jest.fn().mockResolvedValue({ followers: [], total: 0 }),
+    getFollowing: jest.fn().mockResolvedValue({ following: [], total: 0 }),
+    getFollowersAfter: jest.fn().mockResolvedValue({ followers: [], total: 0 }),
+    getFollowingAfter: jest.fn().mockResolvedValue({ following: [], total: 0 }),
+    searchPosts: jest.fn().mockResolvedValue({ posts: [], total: 0 }),
+    getTokenMetadata: jest.fn().mockResolvedValue(null),
+  } as jest.Mocked<Database>;
+}
+
+describe("Smoke Tests", () => {
+  let db: jest.Mocked<Database>;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    db = makeMockDb();
+    app = createApp(db);
+  });
+
+  describe("GET /version", () => {
+    it("returns 200 with version metadata", async () => {
+      const res = await request(app).get("/version");
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        version: expect.any(String),
+        git_commit: expect.any(String),
+        build_time: expect.any(String),
+        node_version: expect.any(String),
+      });
+    });
+
+    it("returns semver for the version field", async () => {
+      const res = await request(app).get("/version");
+      expect(res.body.version).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    it("defaults git_commit to unknown", async () => {
+      const res = await request(app).get("/version");
+      expect(res.body.git_commit).toBe("unknown");
+    });
+  });
+
+  describe("CORS headers", () => {
+    it("includes Access-Control-Allow-Origin on API routes", async () => {
+      const res = await request(app).get("/health");
+      expect(res.headers["access-control-allow-origin"]).toBeDefined();
+    });
+
+    it("includes Access-Control-Allow-Origin on /version", async () => {
+      const res = await request(app).get("/version");
+      expect(res.headers["access-control-allow-origin"]).toBeDefined();
+    });
+
+    it("responds to OPTIONS preflight on API routes", async () => {
+      const res = await request(app).options("/api/profiles/test");
+      expect(res.status).toBe(204);
+      expect(res.headers["access-control-allow-origin"]).toBeDefined();
+      expect(res.headers["access-control-allow-methods"]).toBeDefined();
+    });
+  });
+
+  describe("Server startup", () => {
+    it("creates an app without throwing", () => {
+      expect(() => createApp(db)).not.toThrow();
+    });
+
+    it("listens on a port and accepts connections", async () => {
+      const http = await import("http");
+      const server = http.createServer(app);
+      await new Promise<void>((resolve) => server.listen(0, resolve));
+
+      const address = server.address() as { port: number };
+      expect(address.port).toBeGreaterThan(0);
+
+      const res = await fetch(`http://127.0.0.1:${address.port}/health`);
+      expect(res.status).toBe(200);
+
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+  });
+
+  describe("Content-Type", () => {
+    it("returns application/json for all API routes", async () => {
+      const res = await request(app).get("/health");
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+    });
+
+    it("returns application/json for error responses", async () => {
+      const res = await request(app).get("/api/nonexistent");
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+    });
+  });
+});

--- a/services/indexer/src/api/index.ts
+++ b/services/indexer/src/api/index.ts
@@ -5,10 +5,31 @@ import rateLimit, { RateLimitRequestHandler } from "express-rate-limit";
 import crypto from "crypto";
 import { Database } from "../db";
 import { ApiErrorResponse, DebugSnapshot } from "./contracts";
-import { ApiErrorResponse } from "./contracts";
 import pkg from "../../package.json";
 
 const VERSION = pkg.version;
+
+// Configurable rate-limiter override for tests (see rate-limit.test.ts).
+let rateLimitWindowMs = 60_000;
+let rateLimitMax = 100;
+
+export function setRateLimit(windowMs: number, max: number): void {
+  rateLimitWindowMs = windowMs;
+  rateLimitMax = max;
+}
+
+function createLimiter(): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs: rateLimitWindowMs,
+    max: rateLimitMax,
+    standardHeaders: true,
+    legacyHeaders: true,
+    message: {
+      error: "Too many requests, please try again later.",
+      code: "RATE_LIMIT_EXCEEDED",
+    },
+  });
+}
 
 // Enable BigInt JSON serialization (Express res.json uses JSON.stringify).
 (BigInt.prototype as unknown as Record<string, unknown>).toJSON = function () {
@@ -185,8 +206,8 @@ export function createApp(db: Database, options: AppOptions = {}): express.Appli
   });
 
   // Apply rate limiting to all /api routes.
-  // const apiLimiter = createLimiter();
-  // app.use("/api", apiLimiter);
+  const apiLimiter = createLimiter();
+  app.use("/api", apiLimiter);
 
   // BE-25: Apply the auth middleware to all /api routes after rate limiting.
   // Routes registered below this line are covered; the health check above is

--- a/services/indexer/src/index.ts
+++ b/services/indexer/src/index.ts
@@ -197,8 +197,8 @@ async function main(): Promise<void> {
   console.log(`[indexer] API server listening on ${HOST}:${PORT}`);
   console.log("[indexer] Database and event streaming disabled for stub mode");
 
-  await ensureEventsTable();
   await runMigrations(pgPool);
+  await ensureEventsTable();
   await ensurePostSearchIndex();
 
   // Create and start API server

--- a/services/indexer/src/migrate.ts
+++ b/services/indexer/src/migrate.ts
@@ -12,21 +12,9 @@ interface MigrationRecord {
   applied_at: Date;
 }
 
-/**
- * Run any pending SQL migrations found in the migrations directory.
- *
- * BE-28: The schema_version table creation is guarded with IF NOT EXISTS.
- * Individual migrations are applied in a transaction so a partially-applied
- * migration can be retried.  Non-fatal schema drift (e.g. a column that
- * already exists from a previous partial run) is caught and logged rather
- * than crashing the process, so the service can start and serve read
- * traffic even when the database is slightly ahead of or behind the
- * expected schema.
- */
 export async function runMigrations(pool: Pool): Promise<void> {
   await ensureSchemaTable(pool);
 
-  // Acquire an advisory lock to prevent concurrent migration runs.
   await pool.query("SELECT pg_advisory_lock($1)", [LOCK_KEY]);
 
   try {
@@ -53,95 +41,26 @@ export async function runMigrations(pool: Pool): Promise<void> {
         await client.query("BEGIN");
         await client.query(sql);
         await client.query(
-          `INSERT INTO ${TABLE_NAME} (version, name) VALUES ($1, $2)`,
+          `INSERT INTO ${TABLE_NAME} (version, name) VALUES ($1, $2) ON CONFLICT (version) DO NOTHING`,
           [version, file]
         );
         await client.query("COMMIT");
         console.log(`[migrate] Applied ${file}`);
       } catch (err) {
-        await client.query("ROLLBACK");
-        console.error(`[migrate] Failed to apply ${file}: ${err}`);
-        // Continue to the next migration instead of crashing.
+        await client.query("ROLLBACK").catch(() => {});
+        console.warn(
+          `[migrate] Could not apply ${file} (schema drift?), skipping: ${String(err)}`
+        );
       } finally {
         client.release();
       }
     }
   } finally {
     await pool.query("SELECT pg_advisory_unlock($1)", [LOCK_KEY]);
-
-      const client = await pool.connect();
-      try {
-        await client.query("BEGIN");
-        await client.query(sql);
-        await client.query(
-          `INSERT INTO ${TABLE_NAME} (version, name) VALUES ($1, $2)`,
-          [version, file]
-        );
-        await client.query("COMMIT");
-        console.log(`[migrate] Applied ${file}`);
-      } catch (err) {
-        await client.query("ROLLBACK");
-        console.error(`[migrate] Failed to apply ${file}: ${err}`);
-        // Continue to the next migration instead of crashing.
-      } finally {
-        client.release();
-      }
-    }
-  } finally {
-    await pool.query("SELECT pg_advisory_unlock($1)", [LOCK_KEY]);
-
-      const client = await pool.connect();
-      try {
-        await client.query("BEGIN");
-        await client.query(sql);
-        await client.query(
-          `INSERT INTO ${TABLE_NAME} (version, name) VALUES ($1, $2)`,
-          [version, file]
-        );
-        await client.query("COMMIT");
-        console.log(`[migrate] Applied ${file}`);
-      } catch (err) {
-        await client.query("ROLLBACK");
-        console.error(`[migrate] Failed to apply ${file}: ${err}`);
-        // Continue to the next migration instead of crashing.
-      } finally {
-        client.release();
-      }
-    }
-  } finally {
-    await pool.query("SELECT pg_advisory_unlock($1)", [LOCK_KEY]);
-    const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-
-    // BE-28: Run each migration inside a transaction so it is atomic. If the
-    // SQL statement fails due to schema drift (e.g. duplicate column) we
-    // catch the error, roll back, log a warning, and continue to the next
-    // migration so the service does not crash on startup.
-    const client = await pool.connect();
-    try {
-      await client.query("BEGIN");
-      await client.query(sql);
-      await client.query(
-        `INSERT INTO ${TABLE_NAME} (version, name) VALUES ($1, $2) ON CONFLICT (version) DO NOTHING`,
-        [version, file]
-      );
-      await client.query("COMMIT");
-      console.log(`[migrate] Applied ${file}`);
-    } catch (err) {
-      await client.query("ROLLBACK").catch(() => {
-        // Swallow rollback errors — nothing useful we can do here.
-      });
-      console.warn(
-        `[migrate] Could not apply ${file} (schema drift?), skipping: ${String(err)}`
-      );
-    } finally {
-      client.release();
-    }
   }
 }
 
 async function ensureSchemaTable(pool: Pool): Promise<void> {
-  // BE-28: CREATE TABLE IF NOT EXISTS is idempotent and tolerates a
-  // pre-existing table with compatible structure.
   await pool.query(`
     CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
       version    TEXT        PRIMARY KEY,
@@ -158,9 +77,6 @@ async function getAppliedMigrations(pool: Pool): Promise<Set<string>> {
     );
     return new Set(result.rows.map((r) => r.version));
   } catch {
-    // BE-28: If the schema_version table does not exist yet (first run
-    // before ensureSchemaTable completed) return an empty set so all
-    // migrations are treated as pending.
     return new Set();
   }
 }


### PR DESCRIPTION
## Summary

Consolidated PR resolving all 4 assigned issues across the Rust contract and TypeScript indexer.

Closes #344
Closes #343
Closes #342
Closes #339

### #344 — Structured error codes (ContractError enum)
- Defined `ContractError` with `#[contracterror]` and 42 named variants
- Replaced all `panic!()` / `assert!()` / `.expect()` calls with `panic_with_error!()`
- Applied to both `lib.rs` and `transaction.rs`

### #343 — Input validation with structured errors
- Updated validation helpers to use `panic_with_error!` with `ContractError`
- Updated all 56 `#[should_panic(expected = ...)]` annotations in `test.rs`

### #342 — Smoke tests for indexer
- Added `smoke.test.ts` covering /version, CORS headers, server startup, Content-Type
- Fixed duplicate import in `api/index.ts`
- Re-enabled rate-limit middleware with `setRateLimit()` export
- Fixed rate-limit test address validation

### #339 — Fix indexer startup order + migrate.ts corruption
- Swapped `runMigrations()` before `ensureEventsTable()` in `index.ts`
- Removed duplicated/corrupted code blocks from `migrate.ts`

## Testing
- All 147 indexer tests pass (jest --no-coverage: 10 suites, 147 tests)
