### PR TITLE
Fix storage initialization checks for all contract entry points

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -438,6 +438,7 @@ impl KovaraContract {
     // ── Profiles ──────────────────────────────────────────────────────────────
 
     pub fn set_profile(env: Env, user: Address, username: String, creator_token: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         user.require_auth();
         validate_username(&env, &username);
@@ -493,6 +494,7 @@ impl KovaraContract {
     }
 
     pub fn get_profile(env: Env, user: Address) -> Option<Profile> {
+        Self::require_initialized(&env);
         let key = StorageKey::Profile(user);
         let result: Option<Profile> = env.storage().persistent().get(&key);
         if result.is_some() {
@@ -512,6 +514,7 @@ impl KovaraContract {
     }
 
     pub fn delete_profile(env: Env, user: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         user.require_auth();
         let key = StorageKey::Profile(user.clone());
@@ -530,6 +533,7 @@ impl KovaraContract {
     }
 
     pub fn get_address_by_username(env: Env, username: String) -> Option<Address> {
+        Self::require_initialized(&env);
         let key = StorageKey::UsernameIndex(username);
         let result: Option<Address> = env.storage().persistent().get(&key);
         if result.is_some() {
@@ -541,6 +545,7 @@ impl KovaraContract {
     // ── Social Graph ──────────────────────────────────────────────────────────
 
     pub fn follow(env: Env, follower: Address, followee: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         follower.require_auth();
 
@@ -579,6 +584,7 @@ impl KovaraContract {
     }
 
     pub fn unfollow(env: Env, follower: Address, followee: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         follower.require_auth();
 
@@ -615,6 +621,7 @@ impl KovaraContract {
     }
 
     pub fn get_following(env: Env, user: Address, offset: u32, limit: u32) -> Vec<Address> {
+        Self::require_initialized(&env);
         if limit == 0 || limit > MAX_PAGINATION_LIMIT {
             panic_with_error!(&env, ContractError::InvalidPaginationLimit);
         }
@@ -631,6 +638,7 @@ impl KovaraContract {
     }
 
     pub fn get_followers(env: Env, user: Address, offset: u32, limit: u32) -> Vec<Address> {
+        Self::require_initialized(&env);
         if limit == 0 || limit > MAX_PAGE_LIMIT {
             panic_with_error!(&env, ContractError::InvalidPaginationLimit);
         }
@@ -649,6 +657,7 @@ impl KovaraContract {
     // ── Block List ────────────────────────────────────────────────────────────
 
     pub fn block_user(env: Env, blocker: Address, blocked: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         blocker.require_auth();
         let key = StorageKey::Blocks(blocker.clone());
@@ -664,6 +673,7 @@ impl KovaraContract {
     }
 
     pub fn unblock_user(env: Env, blocker: Address, blocked: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         blocker.require_auth();
         let key = StorageKey::Blocks(blocker.clone());
@@ -679,6 +689,7 @@ impl KovaraContract {
     }
 
     pub fn is_blocked(env: Env, blocker: Address, blocked: Address) -> bool {
+        Self::require_initialized(&env);
         let blocks: Map<Address, ()> = env
             .storage()
             .persistent()
@@ -690,6 +701,7 @@ impl KovaraContract {
     // ── Posts ─────────────────────────────────────────────────────────────────
 
     pub fn create_post(env: Env, author: Address, content: String) -> u64 {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         author.require_auth();
         validate_content(&env, &content);
@@ -728,10 +740,12 @@ impl KovaraContract {
     /// Returns the total number of posts ever created, not the current active count.
     /// This counter is never decremented when posts are deleted.
     pub fn get_post_count(env: Env) -> u64 {
+        Self::require_initialized(&env);
         env.storage().instance().get(&POST_CT).unwrap_or(0u64)
     }
 
     pub fn get_post(env: Env, id: u64) -> Option<Post> {
+        Self::require_initialized(&env);
         let key = StorageKey::Post(id);
         let result: Option<Post> = env.storage().persistent().get(&key);
         if result.is_some() {
@@ -741,6 +755,7 @@ impl KovaraContract {
     }
 
     pub fn delete_post(env: Env, author: Address, post_id: u64) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         author.require_auth();
         let key = StorageKey::Post(post_id);
@@ -774,6 +789,7 @@ impl KovaraContract {
     }
 
     pub fn get_posts_by_author(env: Env, author: Address, offset: u32, limit: u32) -> Vec<u64> {
+        Self::require_initialized(&env);
         if limit == 0 || limit > MAX_PAGINATION_LIMIT {
             panic_with_error!(&env, ContractError::InvalidPaginationLimit);
         }
@@ -796,6 +812,7 @@ impl KovaraContract {
     // ── Reactions ─────────────────────────────────────────────────────────────
 
     pub fn like_post(env: Env, user: Address, post_id: u64) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         user.require_auth();
 
@@ -824,12 +841,14 @@ impl KovaraContract {
     }
 
     pub fn get_like_count(env: Env, post_id: u64) -> u64 {
+        Self::require_initialized(&env);
         let key = StorageKey::Post(post_id);
         let result: Option<Post> = env.storage().persistent().get(&key);
         result.map(|p| p.like_count).unwrap_or(0)
     }
 
     pub fn has_liked(env: Env, user: Address, post_id: u64) -> bool {
+        Self::require_initialized(&env);
         let key = StorageKey::Like(post_id, user);
         env.storage().persistent().has(&key)
     }
@@ -837,6 +856,7 @@ impl KovaraContract {
     // ── Tipping ───────────────────────────────────────────────────────────────
 
     pub fn tip(env: Env, tipper: Address, post_id: u64, token: Address, amount: i128) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         if amount <= 0 {
             panic_with_error!(&env, ContractError::TipAmountMustBePositive);
@@ -934,6 +954,7 @@ impl KovaraContract {
         initial_admins: Vec<Address>,
         threshold: u32,
     ) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         admin.require_auth();
         Self::require_admin(&env);
@@ -975,6 +996,7 @@ impl KovaraContract {
         token: Address,
         amount: i128,
     ) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         if amount <= 0 {
             panic_with_error!(&env, ContractError::DepositAmountMustBePositive);
@@ -1019,6 +1041,7 @@ impl KovaraContract {
         amount: i128,
         recipient: Address,
     ) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         if amount <= 0 {
             panic_with_error!(&env, ContractError::MustBePositive);
@@ -1065,6 +1088,7 @@ impl KovaraContract {
     }
 
     pub fn get_pool(env: Env, pool_id: Symbol) -> Option<Pool> {
+        Self::require_initialized(&env);
         let key = StorageKey::Pool(pool_id);
         let result: Option<Pool> = env.storage().persistent().get(&key);
         if result.is_some() {
@@ -1074,6 +1098,7 @@ impl KovaraContract {
     }
 
     pub fn get_pool_admins(env: Env, pool_id: Symbol) -> Vec<Address> {
+        Self::require_initialized(&env);
         let key = StorageKey::Pool(pool_id);
         let pool: Pool = env
             .storage()
@@ -1087,6 +1112,7 @@ impl KovaraContract {
     }
 
     pub fn add_pool_admin(env: Env, signers: Vec<Address>, pool_id: Symbol, new_admin: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
@@ -1119,6 +1145,7 @@ impl KovaraContract {
     }
 
     pub fn remove_pool_admin(env: Env, signers: Vec<Address>, pool_id: Symbol, admin: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         let key = StorageKey::Pool(pool_id.clone());
         let mut pool: Pool = env
@@ -1162,6 +1189,7 @@ impl KovaraContract {
     }
 
     pub fn update_pool_threshold(env: Env, signers: Vec<Address>, pool_id: Symbol, threshold: u32) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         if threshold == 0 {
             panic_with_error!(&env, ContractError::ThresholdMustBePositive);
@@ -1205,6 +1233,7 @@ impl KovaraContract {
     // ── Fee & Treasury ────────────────────────────────────────────────────────
 
     pub fn set_fee(env: Env, fee_bps: u32) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         Self::require_admin(&env);
         if fee_bps > 10_000 {
@@ -1221,6 +1250,7 @@ impl KovaraContract {
     }
 
     pub fn set_treasury(env: Env, treasury: Address) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         Self::require_admin(&env);
         let old_treasury = Self::get_treasury(env.clone()).unwrap_or_else(|| {
@@ -1236,14 +1266,17 @@ impl KovaraContract {
     }
 
     pub fn get_fee_bps(env: Env) -> u32 {
+        Self::require_initialized(&env);
         env.storage().instance().get(&FEE_BPS).unwrap_or(0u32)
     }
 
     pub fn get_treasury(env: Env) -> Option<Address> {
+        Self::require_initialized(&env);
         env.storage().instance().get(&TREASURY)
     }
 
     pub fn set_tip_cooldown_window(env: Env, cooldown_ledgers: u32) {
+        Self::require_initialized(&env);
         Self::bump_instance(&env);
         Self::require_admin(&env);
         if cooldown_ledgers == 0 {
@@ -1255,6 +1288,7 @@ impl KovaraContract {
     }
 
     pub fn get_tip_cooldown_window(env: Env) -> u32 {
+        Self::require_initialized(&env);
         env.storage()
             .instance()
             .get(&TIP_COOLDOWN_WINDOW)
@@ -1272,6 +1306,17 @@ impl KovaraContract {
     }
 
     // ── Internal Helpers ──────────────────────────────────────────────────────
+
+    fn require_initialized(env: &Env) {
+        if !env
+            .storage()
+            .instance()
+            .get::<Symbol, bool>(&INITIALIZED)
+            .unwrap_or(false)
+        {
+            panic_with_error!(env, ContractError::NotInitialized);
+        }
+    }
 
     fn require_admin(env: &Env) {
         let admin: Address = env


### PR DESCRIPTION
## Summary

Added a centralized `require_initialized()` guard that verifies the `INITIALIZED` flag before any persistent storage access. This prevents the contract from operating in a partially initialized state, which could lead to undefined behavior or silent data corruption.

### Changes

- Added `require_initialized()` helper function that checks the `INITIALIZED` instance storage key
- Applied the initialization check to all public entry points (except `initialize` and `get_profile_count`)
- All storage-mutating and storage-reading functions now validate initialization state before proceeding
- Follows existing coding conventions and does not introduce breaking changes

Closes #353
Closes #354
Closes #345 
Closes #355