### PR TITLE
Add bidirectional block checks for tip and follow interactions

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -547,6 +547,9 @@ impl KovaraContract {
         if Self::is_blocked(env.clone(), followee.clone(), follower.clone()) {
             panic_with_error!(&env, ContractError::Blocked);
         }
+        if Self::is_blocked(env.clone(), follower.clone(), followee.clone()) {
+            panic_with_error!(&env, ContractError::Blocked);
+        }
 
         let following_key = StorageKey::Following(follower.clone());
         let mut following_list: Vec<Address> = env
@@ -849,6 +852,9 @@ impl KovaraContract {
         });
 
         if Self::is_blocked(env.clone(), post.author.clone(), tipper.clone()) {
+            panic_with_error!(&env, ContractError::Blocked);
+        }
+        if Self::is_blocked(env.clone(), tipper.clone(), post.author.clone()) {
             panic_with_error!(&env, ContractError::Blocked);
         }
 


### PR DESCRIPTION
## Summary

The existing block check only verified one direction (e.g., whether the author blocked the tipper). This PR adds the reverse check to ensure that if either party has blocked the other, the interaction is rejected.

### Changes

- `tip()`: reject tip if tipper has blocked the author (in addition to the existing author-blocks-tipper check)
- `follow()`: reject follow if follower has blocked the followee (in addition to the existing followee-blocks-follower check)

This ensures moderation rules are enforced symmetrically, preventing blocked users from interacting with each other in either direction.

Closes #356
Closes #357
Closes #358
Closes #359