### PR TITLE
Add safeguards for fee and treasury configuration

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -67,6 +67,8 @@ pub enum ContractError {
     CreatorTokenCannotBeContract = 40,
     ContentTooShort = 41,
     ContentTooLong = 42,
+    TreasuryCannotBeContract = 43,
+    NoOpFeeUpdate = 44,
 }
 
 // ── Instance-storage key constants (small scalars, not contracttype) ──────────
@@ -1211,6 +1213,9 @@ impl KovaraContract {
             panic_with_error!(&env, ContractError::InvalidFee);
         }
         let old_fee_bps = Self::get_fee_bps(env.clone());
+        if old_fee_bps == fee_bps {
+            panic_with_error!(&env, ContractError::NoOpFeeUpdate);
+        }
         env.storage().instance().set(&FEE_BPS, &fee_bps);
         FeeUpdatedEvent {
             name: symbol_short!("fee_upd"),
@@ -1223,9 +1228,15 @@ impl KovaraContract {
     pub fn set_treasury(env: Env, treasury: Address) {
         Self::bump_instance(&env);
         Self::require_admin(&env);
+        if treasury == env.current_contract_address() {
+            panic_with_error!(&env, ContractError::TreasuryCannotBeContract);
+        }
         let old_treasury = Self::get_treasury(env.clone()).unwrap_or_else(|| {
             panic_with_error!(&env, ContractError::TreasuryNotSet);
         });
+        if old_treasury == treasury {
+            panic_with_error!(&env, ContractError::NoOpFeeUpdate);
+        }
         env.storage().instance().set(&TREASURY, &treasury);
         TreasuryUpdatedEvent {
             name: symbol_short!("treas_upd"),


### PR DESCRIPTION
## Summary

Added input validation to prevent misconfigurations in the fee and treasury update functions.

### Changes

- `set_treasury()`: reject if new treasury is the contract address itself (would cause fees to loop back into the contract)
- `set_treasury()`: reject if new treasury is identical to current (no-op update with unnecessary event emission)
- `set_fee()`: reject if new `fee_bps` is identical to current (no-op)
- Added `TreasuryCannotBeContract` and `NoOpFeeUpdate` error variants

Closes #368
Closes #369
Closes #370
Closes #371