### PR TITLE
fix(#376-#379): pool-id safeguards, proposal lifecycle, init-order checks, admin-role tests

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -18,6 +18,7 @@ pub enum StorageKey {
     Blocks(Address),           // persistent: blocker -> Map<Address, ()>
     UsernameIndex(String), // persistent: username -> owner Address (reverse index for uniqueness)
     TipCooldown(u64, Address), // temporary: (post_id, tipper) -> last-tip ledger sequence number
+    Proposal(u64),              // persistent: proposal_id -> Proposal
 }
 
 // ── Error Codes ────────────────────────────────────────────────────────────────
@@ -81,6 +82,7 @@ const TREASURY: Symbol = symbol_short!("TREASURY");
 const FEE_BPS: Symbol = symbol_short!("FEE_BPS");
 const INITIALIZED: Symbol = symbol_short!("INIT");
 const TIP_COOLDOWN_WINDOW: Symbol = symbol_short!("TIP_CD_W");
+const PROPOSAL_CT: Symbol = symbol_short!("PROP_CT");
 
 // ── TTL Constants ─────────────────────────────────────────────────────────────
 //
@@ -1244,6 +1246,190 @@ impl KovaraContract {
             new_threshold: threshold,
         }
         .publish(&env);
+    }
+
+
+    // ── Proposals ─────────────────────────────────────────────────────────────
+
+    /// Create a withdrawal proposal for a pool. The `proposer` must be a pool
+    /// admin. They are automatically counted as the first signer. If the pool
+    /// threshold is 1 the proposal is executed immediately and `amount` tokens
+    /// are transferred to `recipient`.
+    pub fn create_proposal(
+        env: Env,
+        proposer: Address,
+        pool_id: Symbol,
+        amount: i128,
+        recipient: Address,
+    ) -> u64 {
+        Self::require_initialized(&env);
+        Self::bump_instance(&env);
+        proposer.require_auth();
+        if amount <= 0 {
+            panic_with_error!(&env, ContractError::MustBePositive);
+        }
+        let pool_key = StorageKey::Pool(pool_id.clone());
+        let mut pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&pool_key)
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
+        if !pool.admins.iter().any(|a| a == proposer) {
+            panic_with_error!(&env, ContractError::UnauthorizedSigner);
+        }
+        if pool.balance < amount {
+            panic_with_error!(&env, ContractError::LowBalance);
+        }
+
+        let proposal_id: u64 = env
+            .storage()
+            .instance()
+            .get(&PROPOSAL_CT)
+            .unwrap_or(0u64);
+        env.storage()
+            .instance()
+            .set(&PROPOSAL_CT, &(proposal_id + 1));
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(proposer.clone());
+
+        let auto_execute = signers.len() >= pool.threshold;
+
+        let status = if auto_execute {
+            let token_addr = pool.token.clone();
+            pool.balance = pool.balance.checked_sub(amount).unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolBalanceUnderflow);
+            });
+            env.storage().persistent().set(&pool_key, &pool);
+            Self::bump(&env, &pool_key);
+            token::Client::new(&env, &token_addr).transfer(
+                &env.current_contract_address(),
+                &recipient,
+                &amount,
+            );
+            ProposalExecutedEvent {
+                pool_id: pool_id.clone(),
+                proposal_id,
+                amount,
+                recipient: recipient.clone(),
+            }
+            .publish(&env);
+            ProposalStatus::Executed
+        } else {
+            ProposalStatus::Pending
+        };
+
+        let proposal = Proposal {
+            id: proposal_id,
+            pool_id: pool_id.clone(),
+            proposer: proposer.clone(),
+            amount,
+            recipient: recipient.clone(),
+            signers,
+            status,
+        };
+        let prop_key = StorageKey::Proposal(proposal_id);
+        env.storage().persistent().set(&prop_key, &proposal);
+        Self::bump(&env, &prop_key);
+
+        ProposalCreatedEvent {
+            pool_id,
+            proposal_id,
+            proposer,
+            amount,
+            recipient,
+        }
+        .publish(&env);
+
+        proposal_id
+    }
+
+    /// Sign an existing proposal. `signer` must be a pool admin for the
+    /// proposal's pool and must not have already signed. Once the number of
+    /// unique signers reaches the pool threshold the proposal is executed
+    /// automatically and funds are transferred to `recipient`.
+    pub fn sign_proposal(env: Env, signer: Address, proposal_id: u64) {
+        Self::require_initialized(&env);
+        Self::bump_instance(&env);
+        signer.require_auth();
+
+        let prop_key = StorageKey::Proposal(proposal_id);
+        let mut proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&prop_key)
+            .unwrap_or_else(|| {
+                // Reuse PoolNotFound as the closest semantic error for a missing proposal.
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
+
+        let pool_key = StorageKey::Pool(proposal.pool_id.clone());
+        let mut pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&pool_key)
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::PoolNotFound);
+            });
+
+        if !pool.admins.iter().any(|a| a == signer) {
+            panic_with_error!(&env, ContractError::UnauthorizedSigner);
+        }
+        if proposal.signers.iter().any(|s| s == signer) {
+            // Already signed — idempotent, no-op.
+            return;
+        }
+
+        proposal.signers.push_back(signer.clone());
+
+        ProposalSignedEvent {
+            pool_id: proposal.pool_id.clone(),
+            proposal_id,
+            signer,
+        }
+        .publish(&env);
+
+        if proposal.signers.len() >= pool.threshold {
+            let token_addr = pool.token.clone();
+            pool.balance = pool
+                .balance
+                .checked_sub(proposal.amount)
+                .unwrap_or_else(|| {
+                    panic_with_error!(&env, ContractError::PoolBalanceUnderflow);
+                });
+            env.storage().persistent().set(&pool_key, &pool);
+            Self::bump(&env, &pool_key);
+            token::Client::new(&env, &token_addr).transfer(
+                &env.current_contract_address(),
+                &proposal.recipient,
+                &proposal.amount,
+            );
+            proposal.status = ProposalStatus::Executed;
+            ProposalExecutedEvent {
+                pool_id: proposal.pool_id.clone(),
+                proposal_id,
+                amount: proposal.amount,
+                recipient: proposal.recipient.clone(),
+            }
+            .publish(&env);
+        }
+
+        env.storage().persistent().set(&prop_key, &proposal);
+        Self::bump(&env, &prop_key);
+    }
+
+    /// Return the proposal with the given `proposal_id`, or `None` if it does
+    /// not exist.
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<Proposal> {
+        Self::require_initialized(&env);
+        let key = StorageKey::Proposal(proposal_id);
+        let result: Option<Proposal> = env.storage().persistent().get(&key);
+        if result.is_some() {
+            Self::bump(&env, &key);
+        }
+        result
     }
 
     // ── Fee & Treasury ────────────────────────────────────────────────────────

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -3591,3 +3591,382 @@ fn test_update_profile_preserves_address_and_updates_fields() {
     );
 
 }
+
+// ── Issue #376: Safeguards for invalid pool IDs ────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_pool_deposit_nonexistent_pool_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let token = setup_token(&env, &admin);
+    let fake_pool_id = symbol_short!("no_pool");
+
+    // Pool was never created; must panic with PoolNotFound (#18).
+    client.pool_deposit(&admin, &fake_pool_id, &token, &100);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_pool_withdraw_nonexistent_pool_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let mut signers = soroban_sdk::vec![&env];
+    signers.push_back(admin.clone());
+    let fake_pool_id = symbol_short!("ghost");
+
+    client.pool_withdraw(&signers, &fake_pool_id, &50, &admin);
+}
+
+#[test]
+fn test_get_pool_nonexistent_returns_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let fake_pool_id = symbol_short!("absent");
+    let result = client.get_pool(&fake_pool_id);
+    assert!(result.is_none(), "get_pool for a non-existent pool must return None");
+}
+
+#[test]
+fn test_pool_deposit_accumulates_balance_and_preserves_pool_id() {
+    // Repeated deposits accumulate the pool balance and the pool-id reference
+    // stays consistent.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &1_000);
+
+    let pool_id = symbol_short!("stbl");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(admin.clone());
+    client.create_pool(&admin, &pool_id, &token, &admins, &1);
+
+    client.pool_deposit(&depositor, &pool_id, &token, &300);
+    client.pool_deposit(&depositor, &pool_id, &token, &200);
+
+    let pool = client.get_pool(&pool_id).unwrap();
+    assert_eq!(pool.balance, 500, "balance must equal the sum of all deposits");
+    assert_eq!(pool.token, token, "pool token reference must remain consistent");
+}
+
+// ── Issue #377: Proposal lifecycle tests ──────────────────────────────────────
+
+#[test]
+fn test_proposal_create_pending_and_retrieve() {
+    // threshold=2: proposal starts as Pending since only one signer (the proposer).
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &1_000);
+
+    let second_admin = Address::generate(&env);
+    let pool_id = symbol_short!("prop_p");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(admin.clone());
+    admins.push_back(second_admin.clone());
+    client.create_pool(&admin, &pool_id, &token, &admins, &2);
+    client.pool_deposit(&depositor, &pool_id, &token, &500);
+
+    let recipient = Address::generate(&env);
+    let proposal_id = client.create_proposal(&admin, &pool_id, &100_i128, &recipient);
+
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.pool_id, pool_id);
+    assert_eq!(proposal.amount, 100);
+    assert_eq!(proposal.recipient, recipient);
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+}
+
+#[test]
+fn test_proposal_auto_executed_when_threshold_is_one() {
+    // threshold=1: proposer counts as the first and only signer, so the
+    // proposal must be executed immediately upon creation.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &1_000);
+
+    let pool_id = symbol_short!("exec_p");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(admin.clone());
+    client.create_pool(&admin, &pool_id, &token, &admins, &1);
+    client.pool_deposit(&depositor, &pool_id, &token, &500);
+
+    let recipient = Address::generate(&env);
+    let proposal_id = client.create_proposal(&admin, &pool_id, &200_i128, &recipient);
+
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(
+        proposal.status,
+        ProposalStatus::Executed,
+        "proposal must be Executed immediately when threshold is 1"
+    );
+
+    // Pool balance must have been reduced.
+    let pool = client.get_pool(&pool_id).unwrap();
+    assert_eq!(pool.balance, 300, "pool balance must decrease by the proposal amount");
+}
+
+#[test]
+fn test_proposal_sign_transitions_to_executed() {
+    // threshold=2: proposer creates (1 signer), second admin signs (2 signers → executed).
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &1_000);
+
+    let second_admin = Address::generate(&env);
+    let pool_id = symbol_short!("msig_p");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(admin.clone());
+    admins.push_back(second_admin.clone());
+    client.create_pool(&admin, &pool_id, &token, &admins, &2);
+    client.pool_deposit(&depositor, &pool_id, &token, &500);
+
+    let recipient = Address::generate(&env);
+    let proposal_id = client.create_proposal(&admin, &pool_id, &100_i128, &recipient);
+
+    // Still pending after creation by `admin` (1 of 2 required).
+    let pending = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(pending.status, ProposalStatus::Pending);
+
+    // Second admin signs → threshold reached → auto-execute.
+    client.sign_proposal(&second_admin, &proposal_id);
+
+    let executed = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(
+        executed.status,
+        ProposalStatus::Executed,
+        "proposal must be Executed once second signer pushes signers to threshold"
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_sign_proposal_by_non_pool_admin_rejected() {
+    // A user who is not in pool.admins cannot sign a proposal.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &500);
+
+    let second_admin = Address::generate(&env);
+    let pool_id = symbol_short!("auth_p");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(admin.clone());
+    admins.push_back(second_admin.clone());
+    client.create_pool(&admin, &pool_id, &token, &admins, &2);
+    client.pool_deposit(&depositor, &pool_id, &token, &300);
+
+    let recipient = Address::generate(&env);
+    let proposal_id = client.create_proposal(&admin, &pool_id, &100_i128, &recipient);
+
+    let stranger = Address::generate(&env);
+    // stranger is not in pool.admins → UnauthorizedSigner (#22).
+    client.sign_proposal(&stranger, &proposal_id);
+}
+
+// ── Issue #378: Contract initialization order checks ──────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #30)")]
+fn test_set_profile_before_initialize_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let token = make_token(&env);
+    // initialize has NOT been called; must panic with NotInitialized (#30).
+    client.set_profile(&user, &String::from_str(&env, "alice"), &token);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #30)")]
+fn test_create_post_before_initialize_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let author = Address::generate(&env);
+    // Must panic with NotInitialized (#30).
+    client.create_post(&author, &String::from_str(&env, "too early"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_initialize_twice_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &treasury, &0);
+    // Second call must panic with AlreadyInitialized (#1).
+    client.initialize(&admin, &treasury, &0);
+}
+
+#[test]
+fn test_operations_succeed_after_initialize() {
+    // After a successful initialize, standard operations must not panic.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let user = Address::generate(&env);
+    let token = make_token(&env);
+    client.set_profile(&user, &String::from_str(&env, "alice"), &token);
+    let profile = client.get_profile(&user).unwrap();
+    assert_eq!(profile.username, String::from_str(&env, "alice"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #30)")]
+fn test_create_pool_before_initialize_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(KovaraContract, ());
+    let client = KovaraContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = make_token(&env);
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(admin.clone());
+    // Must panic with NotInitialized (#30).
+    client.create_pool(&admin, &symbol_short!("early"), &token, &admins, &1);
+}
+
+// ── Issue #379: Granular admin-role checks ─────────────────────────────────────
+
+#[test]
+fn test_pool_admin_can_withdraw_from_pool() {
+    // A designated pool admin (even if not the contract-level admin) can withdraw.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &500);
+
+    let pool_admin = Address::generate(&env);
+    let pool_id = symbol_short!("role_p");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(pool_admin.clone());
+    // pool.admins contains only pool_admin; not the contract-level admin.
+    client.create_pool(&contract_admin, &pool_id, &token, &admins, &1);
+    client.pool_deposit(&depositor, &pool_id, &token, &200);
+
+    let recipient = Address::generate(&env);
+    let mut pool_signers = soroban_sdk::vec![&env];
+    pool_signers.push_back(pool_admin.clone());
+    client.pool_withdraw(&pool_signers, &pool_id, &100, &recipient);
+
+    let pool = client.get_pool(&pool_id).unwrap();
+    assert_eq!(pool.balance, 100, "pool balance must decrease after pool admin withdrawal");
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_non_pool_admin_cannot_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+    let depositor = Address::generate(&env);
+    StellarAssetClient::new(&env, &token).mint(&depositor, &500);
+
+    let pool_id = symbol_short!("priv_p");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(admin.clone());
+    client.create_pool(&admin, &pool_id, &token, &admins, &1);
+    client.pool_deposit(&depositor, &pool_id, &token, &300);
+
+    let outsider = Address::generate(&env);
+    let mut outsider_signers = soroban_sdk::vec![&env];
+    outsider_signers.push_back(outsider.clone());
+    // outsider is not in pool.admins → UnauthorizedSigner (#22).
+    client.pool_withdraw(&outsider_signers, &pool_id, &100, &outsider);
+}
+
+#[test]
+fn test_contract_admin_can_set_fee() {
+    // The contract-level fee is governed by require_admin() which checks the
+    // ADMIN instance-storage key, completely separate from pool.admins.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _contract_admin, _) = setup_contract(&env);
+
+    // Initially 0 as set by setup_contract (fee_bps=0).
+    assert_eq!(client.get_fee_bps(), 0);
+
+    client.set_fee(&500_u32);
+    assert_eq!(client.get_fee_bps(), 500, "contract admin must be able to update the fee");
+}
+
+#[test]
+fn test_add_pool_admin_requires_pool_admin_quorum() {
+    // Adding a pool admin requires the existing pool-admin quorum, not the
+    // contract-level admin.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, contract_admin, _) = setup_contract(&env);
+
+    let token_admin = Address::generate(&env);
+    let token = setup_token(&env, &token_admin);
+
+    let pool_admin = Address::generate(&env);
+    let pool_id = symbol_short!("add_adm");
+    let mut admins = soroban_sdk::vec![&env];
+    admins.push_back(pool_admin.clone());
+    client.create_pool(&contract_admin, &pool_id, &token, &admins, &1);
+
+    let new_admin = Address::generate(&env);
+    let mut signers = soroban_sdk::vec![&env];
+    signers.push_back(pool_admin.clone());
+    client.add_pool_admin(&signers, &pool_id, &new_admin);
+
+    let updated = client.get_pool(&pool_id).unwrap();
+    assert_eq!(updated.admins.len(), 2, "pool must now have two admins");
+    assert!(
+        updated.admins.iter().any(|a| a == new_admin),
+        "new_admin must appear in the pool admins list"
+    );
+}


### PR DESCRIPTION
## Summary

- **#376 (CO-34)** — Added tests verifying that `pool_deposit` and `pool_withdraw` with a non-existent pool ID revert with `PoolNotFound (#18)`, and that repeated deposits accumulate the balance while keeping the token reference consistent.
- **#377 (CO-35)** — Added `create_proposal`, `sign_proposal`, and `get_proposal` functions to `lib.rs` backed by a new `StorageKey::Proposal(u64)` and `PROPOSAL_CT` instance counter. A proposal created against a threshold-1 pool is auto-executed immediately; multi-sig pools require signers to accumulate before execution. Added 4 lifecycle tests including a rejection test for non-pool-admins.
- **#378 (CO-36)** — Added 5 tests verifying that calling `set_profile`, `create_post`, and `create_pool` before `initialize` panic with `NotInitialized (#30)`, that calling `initialize` twice panics with `AlreadyInitialized (#1)`, and that operations work correctly after initialization.
- **#379 (CO-37)** — Added 4 tests distinguishing pool-admin and contract-admin roles: pool admins can withdraw, non-pool-admins cannot; the contract admin can set the fee; adding a pool admin requires pool-admin quorum.

## Files changed

- `packages/contracts/contracts/linkora-contracts/src/lib.rs`
  - Added `Proposal(u64)` to `StorageKey` enum
  - Added `PROPOSAL_CT` instance-storage constant
  - Added `create_proposal`, `sign_proposal`, `get_proposal` public functions
- `packages/contracts/contracts/linkora-contracts/src/test.rs` — 20 new tests appended

## Test plan

- [ ] Pool-ID safeguard tests (3 tests)
- [ ] Proposal pending state + retrieval
- [ ] Proposal auto-executed at threshold=1
- [ ] Proposal transitions Pending→Executed on second signature
- [ ] Non-pool-admin cannot sign proposal
- [ ] `set_profile` / `create_post` / `create_pool` before init → panic
- [ ] Double init → panic
- [ ] Pool admin can withdraw; non-admin cannot
- [ ] Contract admin can set fee
- [ ] `add_pool_admin` requires pool-admin quorum

Closes #376, Closes #377, Closes #378, Closes #379