### PR TITLE
fix(mobile): real pool details, pagination, deposit validation

### DIFF
--- a/Backend/src/api/__tests__/routes.test.ts
+++ b/Backend/src/api/__tests__/routes.test.ts
@@ -566,9 +566,41 @@ describe("API Routes", () => {
       expect(res.body).toMatchObject({ code: "NOT_FOUND" });
     });
 
-    it("returns 404 for empty pool id (no route match)", async () => {
-      const res = await request(app).get("/api/pools/");
-      expect(res.status).toBe(404);
+    it("lists pools on GET /api/pools/", async () => {
+      db.listPools.mockResolvedValueOnce({
+        pools: [
+          {
+            pool_id: "pool1",
+            token: "GTOKEN",
+            balance: BigInt(1000),
+            admins: ["GADMIN1"],
+            threshold: 1,
+            created_ledger: 50,
+            updated_ledger: 100,
+          },
+        ],
+        total: 1,
+      });
+      db.getTokenMetadata.mockResolvedValueOnce({
+        name: "TestToken",
+        symbol: "TST",
+        decimals: 7,
+      });
+
+      const res = await request(app).get("/api/pools/?limit=10&offset=0");
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        total: 1,
+        limit: 10,
+        offset: 0,
+        has_more: false,
+      });
+      expect(res.body.pools).toHaveLength(1);
+      expect(res.body.pools[0]).toMatchObject({
+        pool_id: "pool1",
+        token: "GTOKEN",
+        token_symbol: "TST",
+      });
     });
   });
 

--- a/Backend/src/api/contracts.ts
+++ b/Backend/src/api/contracts.ts
@@ -46,10 +46,15 @@ export interface FollowingResponse extends PaginationResponse {
   prev_offset: number | null;
 }
 
-export interface PoolResponse extends Pool {
+export interface PoolResponse extends PoolRecord {
   token_name?: string;
   token_symbol?: string;
   token_decimals?: number;
+}
+
+export interface PoolListResponse extends PaginationResponse {
+  pools: PoolResponse[];
+  total: number;
 }
 
 export interface SearchPost {

--- a/Backend/src/api/routes/pools.ts
+++ b/Backend/src/api/routes/pools.ts
@@ -1,10 +1,92 @@
 import { Router, Request, Response } from "express";
-import { Database } from "../../db";
-import { ApiErrorResponse, PoolResponse } from "../contracts";
+import { Database, PoolRecord } from "../../db";
+import { ApiErrorResponse, PoolListResponse, PoolResponse } from "../contracts";
 import { serializeBigInt } from "../index";
+
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 20;
+const DEFAULT_OFFSET = 0;
+
+function serializePool(
+  pool: PoolRecord,
+  meta?: { token_name?: string; token_symbol?: string; token_decimals?: number }
+): Record<string, unknown> {
+  return serializeBigInt({
+    pool_id: pool.pool_id,
+    token: pool.token,
+    balance: pool.balance,
+    admins: pool.admins,
+    threshold: pool.threshold,
+    created_ledger: pool.created_ledger,
+    updated_ledger: pool.updated_ledger,
+    ...meta,
+  }) as Record<string, unknown>;
+}
 
 export function createPoolsRouter(db: Database): Router {
   const router = Router();
+
+  /**
+   * GET /pools?limit=<n>&offset=<n>
+   * Lists pools with limit/offset pagination and has_more.
+   */
+  router.get(
+    "/",
+    async (req: Request, res: Response<PoolListResponse | ApiErrorResponse>): Promise<void> => {
+      if (req.correlationId) {
+        res.set("X-Correlation-Id", req.correlationId);
+      }
+
+      const rawLimit = req.query.limit !== undefined ? Number(req.query.limit) : DEFAULT_LIMIT;
+      const rawOffset = req.query.offset !== undefined ? Number(req.query.offset) : DEFAULT_OFFSET;
+
+      if (!Number.isInteger(rawLimit) || rawLimit < 1) {
+        res.status(400).json({ error: "limit must be a positive integer", code: "INVALID_QUERY" });
+        return;
+      }
+      if (rawLimit > MAX_LIMIT) {
+        res.status(400).json({ error: `limit cannot exceed ${MAX_LIMIT}`, code: "LIMIT_EXCEEDED" });
+        return;
+      }
+      if (!Number.isInteger(rawOffset) || rawOffset < 0) {
+        res
+          .status(400)
+          .json({ error: "offset must be a non-negative integer", code: "INVALID_QUERY" });
+        return;
+      }
+
+      const { pools, total } = await db.listPools({ limit: rawLimit, offset: rawOffset });
+
+      const enriched = await Promise.all(
+        pools.map(async (pool) => {
+          let token_name: string | undefined;
+          let token_symbol: string | undefined;
+          let token_decimals: number | undefined;
+          try {
+            const meta = await db.getTokenMetadata(pool.token);
+            if (meta) {
+              token_name = meta.name;
+              token_symbol = meta.symbol;
+              token_decimals = meta.decimals;
+            }
+          } catch {
+            token_name = "unknown";
+            token_symbol = "UNK";
+            token_decimals = 7;
+          }
+          return serializePool(pool, { token_name, token_symbol, token_decimals });
+        })
+      );
+
+      res.json({
+        pools: enriched,
+        total,
+        limit: rawLimit,
+        offset: rawOffset,
+        has_more: rawOffset + pools.length < total,
+      } as unknown as PoolListResponse);
+    }
+  );
 
   /**
    * GET /pools/:id
@@ -15,10 +97,10 @@ export function createPoolsRouter(db: Database): Router {
     async (req: Request, res: Response<PoolResponse | ApiErrorResponse>): Promise<void> => {
       const { id } = req.params;
 
-if (!id || typeof id !== "string" || id.trim() === "") {
-         res.status(400).json({ error: "Invalid pool ID: must be a non-empty string", code: "INVALID_ID" });
-         return;
-       }
+      if (!id || typeof id !== "string" || id.trim() === "") {
+        res.status(400).json({ error: "Invalid pool ID: must be a non-empty string", code: "INVALID_ID" });
+        return;
+      }
 
       const pool = await db.getPool(id);
       if (!pool) {

--- a/apps/mobile/__tests__/usePoolDeposit.test.ts
+++ b/apps/mobile/__tests__/usePoolDeposit.test.ts
@@ -1,0 +1,59 @@
+import {
+  parseAmountToUnits,
+  DEFAULT_TOKEN_DECIMALS,
+} from '../hooks/usePoolDeposit';
+
+describe('parseAmountToUnits', () => {
+  it('accepts whole numbers within decimal bounds', () => {
+    expect(parseAmountToUnits('1', 7)).toEqual({ ok: true, units: '10000000' });
+    expect(parseAmountToUnits('10', 2)).toEqual({ ok: true, units: '1000' });
+  });
+
+  it('accepts fractional amounts at exact decimal precision', () => {
+    expect(parseAmountToUnits('1.5', 7)).toEqual({ ok: true, units: '15000000' });
+    expect(parseAmountToUnits('0.0000001', 7)).toEqual({ ok: true, units: '1' });
+    expect(parseAmountToUnits('1.23', 2)).toEqual({ ok: true, units: '123' });
+  });
+
+  it('rejects excess fractional digits', () => {
+    const result = parseAmountToUnits('1.12345678', 7);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/too many decimal places/i);
+    }
+  });
+
+  it('rejects zero and negative-looking values', () => {
+    expect(parseAmountToUnits('0', 7).ok).toBe(false);
+    expect(parseAmountToUnits('0.0', 7).ok).toBe(false);
+    expect(parseAmountToUnits('0.0000000', 7).ok).toBe(false);
+    expect(parseAmountToUnits('-1', 7).ok).toBe(false);
+  });
+
+  it('rejects empty, scientific notation, and non-numeric input', () => {
+    expect(parseAmountToUnits('', 7).ok).toBe(false);
+    expect(parseAmountToUnits('   ', 7).ok).toBe(false);
+    expect(parseAmountToUnits('1e7', 7).ok).toBe(false);
+    expect(parseAmountToUnits('abc', 7).ok).toBe(false);
+    expect(parseAmountToUnits('1.2.3', 7).ok).toBe(false);
+  });
+
+  it('rejects invalid decimals configuration', () => {
+    expect(parseAmountToUnits('1', -1).ok).toBe(false);
+    expect(parseAmountToUnits('1', 1.5).ok).toBe(false);
+    expect(parseAmountToUnits('1', 19).ok).toBe(false);
+  });
+
+  it('uses DEFAULT_TOKEN_DECIMALS of 7', () => {
+    expect(DEFAULT_TOKEN_DECIMALS).toBe(7);
+    expect(parseAmountToUnits('1', DEFAULT_TOKEN_DECIMALS)).toEqual({
+      ok: true,
+      units: '10000000',
+    });
+  });
+
+  it('handles leading zeros and plus sign', () => {
+    expect(parseAmountToUnits('+1.5', 2)).toEqual({ ok: true, units: '150' });
+    expect(parseAmountToUnits('01.50', 2)).toEqual({ ok: true, units: '150' });
+  });
+});

--- a/apps/mobile/app/(tabs)/pools.tsx
+++ b/apps/mobile/app/(tabs)/pools.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   ActivityIndicator,
   TouchableOpacity,
+  RefreshControl,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { PoolCard } from "../../components/PoolCard";
@@ -17,13 +18,15 @@ import { useTheme } from "../../theme/useTheme";
 export default function PoolsScreen() {
   const router = useRouter();
   const { theme } = useTheme();
-  const { pools, loading, error, errorCode, refresh } = usePools();
+  const { pools, loading, error, errorCode, hasMore, loadMore, refresh } = usePools();
 
   const handlePoolPress = (poolId: string) => {
     router.push(`/pool/${poolId}`);
   };
 
-  if (loading) {
+  const isInitialLoad = loading && pools.length === 0;
+
+  if (isInitialLoad) {
     return (
       <View style={styles.container}>
         <View style={styles.header}>
@@ -37,7 +40,7 @@ export default function PoolsScreen() {
     );
   }
 
-  if (error) {
+  if (error && pools.length === 0) {
     return (
       <View style={styles.container}>
         <View style={styles.header}>
@@ -66,7 +69,27 @@ export default function PoolsScreen() {
   }
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      refreshControl={
+        <RefreshControl
+          refreshing={loading && pools.length > 0}
+          onRefresh={refresh}
+          tintColor={theme.colors.brand.primary}
+          colors={[theme.colors.brand.primary]}
+        />
+      }
+      onScroll={({ nativeEvent }) => {
+        const { layoutMeasurement, contentOffset, contentSize } = nativeEvent;
+        const nearBottom =
+          layoutMeasurement.height + contentOffset.y >= contentSize.height - 120;
+        if (nearBottom && hasMore && !loading) {
+          loadMore();
+        }
+      }}
+      scrollEventThrottle={200}
+    >
       <View style={styles.header}>
         <Text style={styles.title}>Pools</Text>
         <Text style={styles.subtitle}>Community funding pools</Text>
@@ -83,7 +106,7 @@ export default function PoolsScreen() {
           >
             <PoolCard
               id={pool.pool_id}
-              name={pool.token}
+              name={pool.token_symbol ?? pool.token}
               description={`${pool.admins.length} admin${pool.admins.length === 1 ? "" : "s"}`}
               totalValue={`${pool.balance.toString()}`}
               participants={pool.admins.length}
@@ -92,6 +115,29 @@ export default function PoolsScreen() {
           </TouchableOpacity>
         ))}
       </View>
+
+      {loading && pools.length > 0 ? (
+        <ActivityIndicator
+          style={styles.footer}
+          color={theme.colors.brand.primary}
+          size="small"
+        />
+      ) : null}
+
+      {!hasMore && pools.length > 0 ? (
+        <Text style={styles.endOfList}>You've reached the end</Text>
+      ) : null}
+
+      {hasMore && !loading ? (
+        <TouchableOpacity
+          style={styles.loadMoreButton}
+          onPress={loadMore}
+          accessibilityRole="button"
+          accessibilityLabel="Load more pools"
+        >
+          <Text style={styles.loadMoreText}>Load more</Text>
+        </TouchableOpacity>
+      ) : null}
     </ScrollView>
   );
 }
@@ -102,7 +148,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#0f172a",
   },
   contentContainer: {
-    paddingBottom: 24,
+    paddingBottom: 32,
   },
   header: {
     paddingHorizontal: 24,
@@ -127,5 +173,28 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+  },
+  footer: {
+    paddingVertical: 16,
+  },
+  endOfList: {
+    textAlign: "center",
+    color: "#64748b",
+    fontSize: 13,
+    paddingVertical: 16,
+  },
+  loadMoreButton: {
+    marginHorizontal: 16,
+    marginTop: 8,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#334155",
+    alignItems: "center",
+  },
+  loadMoreText: {
+    color: "#cbd5e1",
+    fontSize: 14,
+    fontWeight: "600",
   },
 });

--- a/apps/mobile/app/pool/[id].tsx
+++ b/apps/mobile/app/pool/[id].tsx
@@ -82,7 +82,7 @@ export default function PoolDetailScreen(): JSX.Element {
         <Text style={styles.sectionValue}>{pool.threshold}</Text>
       </View>
 
-      <PoolDepositForm poolId={pool.pool_id} token={pool.token} />
+      <PoolDepositForm poolId={pool.pool_id} token={pool.token} tokenDecimals={pool.token_decimals} />
 
       {isCurrentUserAdmin && (
         <View style={styles.adminSection}>

--- a/apps/mobile/components/PoolDepositForm.tsx
+++ b/apps/mobile/components/PoolDepositForm.tsx
@@ -8,27 +8,47 @@ import {
   ActivityIndicator,
   Alert,
 } from 'react-native';
-import { usePoolDeposit } from '../hooks/usePoolDeposit';
+import { usePoolDeposit, parseAmountToUnits, DEFAULT_TOKEN_DECIMALS } from '../hooks/usePoolDeposit';
 
 interface PoolDepositFormProps {
   poolId: string;
   token: string;
+  /** Optional decimals from pool token metadata; defaults to Stellar 7. */
+  tokenDecimals?: number;
   onSuccess?: () => void;
 }
 
-export function PoolDepositForm({ poolId, token, onSuccess }: PoolDepositFormProps) {
+export function PoolDepositForm({
+  poolId,
+  token,
+  tokenDecimals,
+  onSuccess,
+}: PoolDepositFormProps) {
   const [amount, setAmount] = useState('');
   const { pending, success, error, txHash, deposit, reset } = usePoolDeposit();
 
+  const decimals =
+    tokenDecimals != null && Number.isInteger(tokenDecimals)
+      ? tokenDecimals
+      : DEFAULT_TOKEN_DECIMALS;
+
   const handleDeposit = useCallback(async () => {
+    if (!poolId?.trim()) {
+      Alert.alert('Validation Error', 'Pool ID is required');
+      return;
+    }
+    if (!token?.trim()) {
+      Alert.alert('Validation Error', 'Token is required');
+      return;
+    }
     if (!amount.trim()) {
       Alert.alert('Validation Error', 'Please enter an amount');
       return;
     }
 
-    const numAmount = parseFloat(amount);
-    if (isNaN(numAmount) || numAmount <= 0) {
-      Alert.alert('Validation Error', 'Amount must be a positive number');
+    const parsed = parseAmountToUnits(amount, decimals);
+    if (!parsed.ok) {
+      Alert.alert('Validation Error', parsed.error);
       return;
     }
 
@@ -38,7 +58,7 @@ export function PoolDepositForm({ poolId, token, onSuccess }: PoolDepositFormPro
       const message = err instanceof Error ? err.message : 'Deposit failed';
       Alert.alert('Error', message);
     }
-  }, [amount, deposit, poolId, token]);
+  }, [amount, deposit, poolId, token, decimals]);
 
   const handleReset = useCallback(() => {
     reset();
@@ -83,34 +103,35 @@ export function PoolDepositForm({ poolId, token, onSuccess }: PoolDepositFormPro
 
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>Amount to Deposit</Text>
+      <Text style={styles.label}>Deposit Amount</Text>
       <View style={styles.inputContainer}>
         <TextInput
           style={styles.input}
-          placeholder="0.00"
-          placeholderTextColor="#64748b"
           value={amount}
           onChangeText={setAmount}
+          placeholder="0.00"
+          placeholderTextColor="#64748b"
           keyboardType="decimal-pad"
           editable={!pending}
-          accessibilityLabel="Deposit amount input"
           testID="deposit-amount-input"
+          accessibilityLabel="Deposit amount"
         />
         <Text style={styles.tokenLabel}>{token}</Text>
       </View>
+      <Text style={styles.note}>
+        Max {decimals} decimal places. Pool and token are verified before signing.
+      </Text>
 
-      <Text style={styles.note}>Token must match pool's configured token</Text>
-
-      {error && (
+      {error ? (
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>{error}</Text>
         </View>
-      )}
+      ) : null}
 
       <TouchableOpacity
         style={[styles.button, pending && styles.buttonDisabled]}
         onPress={handleDeposit}
-        disabled={pending || !amount}
+        disabled={pending}
         accessibilityRole="button"
         accessibilityLabel={pending ? 'Processing deposit' : 'Confirm deposit'}
         testID="deposit-button"

--- a/apps/mobile/hooks/usePool.ts
+++ b/apps/mobile/hooks/usePool.ts
@@ -1,34 +1,19 @@
 import { useState, useEffect, useCallback } from "react";
-import type { Pool } from "../../../packages/sdk/src/types";
+import type { Pool } from "../utils/indexerClient";
+import { getPoolById } from "../utils/indexerClient";
 import { IndexerError } from "../../../packages/sdk/src/errors";
 import type { IndexerErrorCode } from "../components/states/ErrorState";
 
-const MOCK_POOLS: Record<string, Pool> = {
-  "pool-1": {
-    pool_id: "pool-1",
-    token: "USDC",
-    balance: BigInt("50000"),
-    admins: ["GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"],
-    threshold: 1,
-  },
-  "pool-2": {
-    pool_id: "pool-2",
-    token: "EUR",
-    balance: BigInt("100000"),
-    admins: [
-      "GXYZ9876543210ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-      "GDEF5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    ],
-    threshold: 2,
-  },
-  "pool-3": {
-    pool_id: "pool-3",
-    token: "BRL",
-    balance: BigInt("25000"),
-    admins: ["GHIJ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"],
-    threshold: 1,
-  },
-};
+const RENDERABLE_ERROR_CODES: ReadonlySet<IndexerErrorCode> = new Set([
+  400, 401, 403, 404, 429, 500, 502, 503, 504,
+]);
+
+function clampStatusCode(raw: number | undefined): IndexerErrorCode {
+  if (typeof raw === "number" && RENDERABLE_ERROR_CODES.has(raw as IndexerErrorCode)) {
+    return raw as IndexerErrorCode;
+  }
+  return 500;
+}
 
 export interface UsePoolReturn {
   pool: Pool | null;
@@ -39,6 +24,10 @@ export interface UsePoolReturn {
   refresh: () => void;
 }
 
+/**
+ * Load a single pool from the configured indexer backend.
+ * Missing / empty IDs surface a 404 without hitting the network.
+ */
 export function usePool(poolId: string): UsePoolReturn {
   const [pool, setPool] = useState<Pool | null>(null);
   const [loading, setLoading] = useState(true);
@@ -50,20 +39,32 @@ export function usePool(poolId: string): UsePoolReturn {
     setError(null);
     setErrorCode(undefined);
 
+    const id = String(poolId ?? "").trim();
+    if (!id) {
+      setPool(null);
+      setErrorCode(404);
+      setError("Pool not found");
+      setLoading(false);
+      return;
+    }
+
     try {
-      await new Promise<void>((resolve) => setTimeout(resolve, 300));
-      const foundPool = MOCK_POOLS[poolId] || null;
+      const foundPool = await getPoolById(id);
       if (!foundPool) {
+        setPool(null);
         setErrorCode(404);
         setError("Pool not found");
+        return;
       }
       setPool(foundPool);
     } catch (err) {
+      setPool(null);
       if (err instanceof IndexerError) {
-        setErrorCode(err.statusCode as IndexerErrorCode);
+        setErrorCode(clampStatusCode(err.statusCode));
         setError(err.message);
       } else {
         setError("Failed to load pool. Please try again.");
+        setErrorCode(500);
       }
     } finally {
       setLoading(false);

--- a/apps/mobile/hooks/usePoolDeposit.ts
+++ b/apps/mobile/hooks/usePoolDeposit.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { getPoolById, type Pool } from '../utils/indexerClient';
 
 export interface DepositState {
   pending: boolean;
@@ -6,10 +7,122 @@ export interface DepositState {
   error: string | null;
   txHash?: string;
 }
- // const signed = await kit.signTransaction({ txXdr: xdrEnv });
+
 export interface UsePoolDepositReturn extends DepositState {
   deposit: (poolId: string, amount: string, token: string) => Promise<void>;
   reset: () => void;
+}
+
+/** Default Stellar asset precision when token metadata is unavailable. */
+export const DEFAULT_TOKEN_DECIMALS = 7;
+
+/**
+ * Parse a human-readable decimal amount into integer base units for the token.
+ * Rejects excess fractional digits, non-finite values, and amounts that cannot
+ * be represented exactly as an integer number of base units.
+ *
+ * Returns the base-unit amount as a bigint string on success.
+ */
+export function parseAmountToUnits(
+  amount: string,
+  decimals: number
+): { ok: true; units: string } | { ok: false; error: string } {
+  if (typeof amount !== 'string') {
+    return { ok: false, error: 'Amount must be a string' };
+  }
+
+  const trimmed = amount.trim();
+  if (!trimmed) {
+    return { ok: false, error: 'Amount is required' };
+  }
+
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 18) {
+    return { ok: false, error: 'Invalid token decimals' };
+  }
+
+  // Reject scientific notation and other non-decimal forms.
+  if (/[eE]/.test(trimmed)) {
+    return { ok: false, error: 'Scientific notation is not supported' };
+  }
+
+  if (!/^\+?\d+(\.\d+)?$/.test(trimmed)) {
+    return { ok: false, error: 'Amount must be a positive decimal number' };
+  }
+
+  const normalized = trimmed.replace(/^\+/, '');
+  const [wholePart, fracPart = ''] = normalized.split('.');
+
+  if (fracPart.length > decimals) {
+    return {
+      ok: false,
+      error: `Amount has too many decimal places (max ${decimals})`,
+    };
+  }
+
+  const paddedFrac = fracPart.padEnd(decimals, '0');
+  const unitsStr = `${wholePart}${paddedFrac}`.replace(/^0+(?=\d)/, '') || '0';
+
+  // Reject zero after scaling (e.g. 0, 0.0, 0.000).
+  if (!/^[1-9]\d*$/.test(unitsStr)) {
+    return { ok: false, error: 'Amount must be greater than zero' };
+  }
+
+  // Guard against values that exceed safe integer range when coerced via Number.
+  // Base units are kept as strings/bigint so large balances remain exact.
+  try {
+    const asBigInt = BigInt(unitsStr);
+    if (asBigInt <= 0n) {
+      return { ok: false, error: 'Amount must be greater than zero' };
+    }
+  } catch {
+    return { ok: false, error: 'Amount is not a valid integer amount' };
+  }
+
+  return { ok: true, units: unitsStr };
+}
+
+/**
+ * Verify the pool exists and that the provided token matches the pool's
+ * configured token before any signing/submit step.
+ */
+export async function validatePoolAndToken(
+  poolId: string,
+  token: string
+): Promise<{ ok: true; pool: Pool } | { ok: false; error: string }> {
+  const id = String(poolId ?? '').trim();
+  if (!id) {
+    return { ok: false, error: 'Pool ID is required' };
+  }
+
+  const tokenStr = String(token ?? '').trim();
+  if (!tokenStr) {
+    return { ok: false, error: 'Token is required' };
+  }
+
+  let pool: Pool | null;
+  try {
+    pool = await getPoolById(id);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to verify pool';
+    return { ok: false, error: message };
+  }
+
+  if (!pool) {
+    return { ok: false, error: 'Pool not found' };
+  }
+
+  if (!pool.token || pool.token.trim() === '') {
+    return { ok: false, error: 'Pool has no token configured' };
+  }
+
+  if (pool.token !== tokenStr) {
+    return {
+      ok: false,
+      error: `Token mismatch: pool is configured for ${pool.token}, got ${tokenStr}`,
+    };
+  }
+
+  return { ok: true, pool };
 }
 
 export function usePoolDeposit(): UsePoolDepositReturn {
@@ -24,14 +137,25 @@ export function usePoolDeposit(): UsePoolDepositReturn {
     setSuccess(false);
 
     try {
-      if (!amount || parseFloat(amount) <= 0) {
-        throw new Error('Amount must be greater than zero');
+      // 1) Pool existence + token configuration must be verified before signing.
+      const poolCheck = await validatePoolAndToken(poolId, token);
+      if (!poolCheck.ok) {
+        throw new Error(poolCheck.error);
       }
 
-      if (!token) {
-        throw new Error('Token is required');
+      const decimals =
+        poolCheck.pool.token_decimals != null &&
+        Number.isInteger(poolCheck.pool.token_decimals)
+          ? poolCheck.pool.token_decimals
+          : DEFAULT_TOKEN_DECIMALS;
+
+      // 2) Enforce token decimals / exact integer units (reject excess precision).
+      const parsed = parseAmountToUnits(amount, decimals);
+      if (!parsed.ok) {
+        throw new Error(parsed.error);
       }
 
+      // Simulated submit — real signing would use `parsed.units` as the contract amount.
       await new Promise<void>((resolve) => setTimeout(resolve, 1500));
 
       const mockTxHash = `0x${Math.random().toString(16).slice(2)}`;

--- a/apps/mobile/hooks/usePools.ts
+++ b/apps/mobile/hooks/usePools.ts
@@ -1,76 +1,110 @@
-import { useState, useEffect, useCallback } from "react";
-import type { Pool } from "../../../packages/sdk/src/types";
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { Pool } from "../utils/indexerClient";
+import { listPools as fetchPoolsFromIndexer } from "../utils/indexerClient";
 import { IndexerError } from "../../../packages/sdk/src/errors";
 import type { IndexerErrorCode } from "../components/states/ErrorState";
 
-const MOCK_POOLS: Pool[] = [
-  {
-    pool_id: "pool-1",
-    token: "USDC",
-    balance: BigInt("50000"),
-    admins: ["GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"],
-    threshold: 1,
-  },
-  {
-    pool_id: "pool-2",
-    token: "EUR",
-    balance: BigInt("100000"),
-    admins: [
-      "GXYZ9876543210ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-      "GDEF5678901234ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    ],
-    threshold: 2,
-  },
-  {
-    pool_id: "pool-3",
-    token: "BRL",
-    balance: BigInt("25000"),
-    admins: ["GHIJ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"],
-    threshold: 1,
-  },
-];
+const PAGE_SIZE = 20;
+
+const RENDERABLE_ERROR_CODES: ReadonlySet<IndexerErrorCode> = new Set([
+  400, 401, 403, 404, 429, 500, 502, 503, 504,
+]);
+
+function clampStatusCode(raw: number | undefined): IndexerErrorCode {
+  if (typeof raw === "number" && RENDERABLE_ERROR_CODES.has(raw as IndexerErrorCode)) {
+    return raw as IndexerErrorCode;
+  }
+  return 500;
+}
 
 export interface UsePoolsReturn {
   pools: Pool[];
   loading: boolean;
   error: string | null;
   errorCode: IndexerErrorCode | undefined;
+  hasMore: boolean;
+  loadMore: () => void;
   refresh: () => void;
 }
 
+/**
+ * Paginated pool list backed by the indexer API.
+ * Additional pages append without duplicates; hasMore reflects end-of-list.
+ */
 export function usePools(): UsePoolsReturn {
   const [pools, setPools] = useState<Pool[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<IndexerErrorCode | undefined>(undefined);
+  const [hasMore, setHasMore] = useState(true);
 
-  const loadPools = useCallback(async () => {
+  const offsetRef = useRef(0);
+  const loadingRef = useRef(false);
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  const load = useCallback(async (offset: number, replace: boolean) => {
+    if (loadingRef.current) return;
+    loadingRef.current = true;
     setLoading(true);
     setError(null);
     setErrorCode(undefined);
 
     try {
-      await new Promise<void>((resolve) => setTimeout(resolve, 300));
-      setPools(MOCK_POOLS);
-    } catch (err) {
-      if (err instanceof IndexerError) {
-        setErrorCode(err.statusCode as IndexerErrorCode);
-        setError(err.message);
+      const { pools: fetched, hasMore: more } = await fetchPoolsFromIndexer(PAGE_SIZE, offset, {});
+
+      setPools((prev) => {
+        if (replace) {
+          seenIdsRef.current = new Set(fetched.map((p) => p.pool_id));
+          return fetched;
+        }
+
+        const next = [...prev];
+        for (const pool of fetched) {
+          if (!seenIdsRef.current.has(pool.pool_id)) {
+            seenIdsRef.current.add(pool.pool_id);
+            next.push(pool);
+          }
+        }
+        return next;
+      });
+
+      setHasMore(more);
+      if (fetched.length > 0) {
+        offsetRef.current = offset + fetched.length;
+      } else if (replace) {
+        offsetRef.current = 0;
+      }
+    } catch (e) {
+      if (e instanceof IndexerError) {
+        setErrorCode(clampStatusCode(e.statusCode));
+        setError(e.message);
       } else {
         setError("Failed to load pools. Please try again.");
+        setErrorCode(500);
       }
     } finally {
       setLoading(false);
+      loadingRef.current = false;
     }
   }, []);
 
   useEffect(() => {
-    loadPools();
-  }, [loadPools]);
+    offsetRef.current = 0;
+    seenIdsRef.current = new Set();
+    void load(0, true);
+  }, [load]);
+
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore) {
+      void load(offsetRef.current, false);
+    }
+  }, [loading, hasMore, load]);
 
   const refresh = useCallback(() => {
-    loadPools();
-  }, [loadPools]);
+    offsetRef.current = 0;
+    seenIdsRef.current = new Set();
+    void load(0, true);
+  }, [load]);
 
-  return { pools, loading, error, errorCode, refresh };
+  return { pools, loading, error, errorCode, hasMore, loadMore, refresh };
 }

--- a/apps/mobile/utils/indexerClient.ts
+++ b/apps/mobile/utils/indexerClient.ts
@@ -178,3 +178,109 @@ export async function getPostById(
     throw err;
   }
 }
+
+
+/** Pool row shape returned by the indexer (balance serialized as string). */
+export interface IndexerPoolRow {
+  pool_id: string;
+  token: string;
+  balance: string | number;
+  admins: string[];
+  threshold: number;
+  created_ledger?: number;
+  updated_ledger?: number;
+  token_name?: string;
+  token_symbol?: string;
+  token_decimals?: number;
+}
+
+export interface IndexerPoolListResponse {
+  pools: IndexerPoolRow[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+/** App-level Pool shape used by pool hooks and UI. */
+export interface Pool {
+  pool_id: string;
+  token: string;
+  balance: bigint;
+  admins: string[];
+  threshold: number;
+  created_ledger?: number;
+  updated_ledger?: number;
+  token_name?: string;
+  token_symbol?: string;
+  token_decimals?: number;
+}
+
+export function poolFromIndexer(row: IndexerPoolRow): Pool {
+  const balanceRaw = row.balance ?? 0;
+  const balance =
+    typeof balanceRaw === "bigint"
+      ? balanceRaw
+      : BigInt(typeof balanceRaw === "string" ? balanceRaw : Math.trunc(Number(balanceRaw)));
+
+  return {
+    pool_id: String(row.pool_id),
+    token: String(row.token ?? ""),
+    balance,
+    admins: Array.isArray(row.admins) ? row.admins.map(String) : [],
+    threshold: Number(row.threshold ?? 0),
+    created_ledger: row.created_ledger != null ? Number(row.created_ledger) : undefined,
+    updated_ledger: row.updated_ledger != null ? Number(row.updated_ledger) : undefined,
+    token_name: row.token_name,
+    token_symbol: row.token_symbol,
+    token_decimals:
+      row.token_decimals != null && Number.isFinite(Number(row.token_decimals))
+        ? Number(row.token_decimals)
+        : undefined,
+  };
+}
+
+/**
+ * Fetch a page of pools from the indexer using limit/offset pagination.
+ */
+export async function listPools(
+  limit = 20,
+  offset = 0,
+  opts: IndexerOptions = {}
+): Promise<{ pools: Pool[]; total: number; hasMore: boolean }> {
+  const safeLimit = Math.min(Math.max(1, Math.floor(limit)), 100);
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const qs = new URLSearchParams({ limit: String(safeLimit), offset: String(safeOffset) });
+
+  const data = await request<IndexerPoolListResponse>(`/api/pools?${qs.toString()}`, {}, opts);
+  return {
+    pools: (data.pools ?? []).map(poolFromIndexer),
+    total: Number(data.total ?? 0),
+    hasMore: Boolean(data.has_more),
+  };
+}
+
+/**
+ * Fetch a single pool by id. Returns null on 404 so callers can handle missing IDs.
+ */
+export async function getPoolById(
+  poolId: string,
+  opts: IndexerOptions = {}
+): Promise<Pool | null> {
+  const id = String(poolId ?? "").trim();
+  if (!id) {
+    return null;
+  }
+
+  try {
+    const row = await request<IndexerPoolRow>(
+      `/api/pools/${encodeURIComponent(id)}`,
+      {},
+      opts
+    );
+    return poolFromIndexer(row);
+  } catch (err) {
+    if (err instanceof IndexerError && err.statusCode === 404) return null;
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
Implements MO-003, MO-005, MO-008, and MO-009 for pool listing, detail loading, and deposit validation.

## Changes

### #520 MO-005 — Load real pool details
- `usePool` now fetches via `getPoolById` from the indexer (`GET /api/pools/:id`)
- Empty / missing IDs return 404 without relying on local `MOCK_POOLS`
- Surfaces indexer errors with status codes for `ErrorState`

### #518   MO-003 — Support pool pagination
- Backend: `GET /api/pools?limit=&offset=` with `has_more`, `total`, enriched token metadata
- Mobile: `usePools` exposes `hasMore`, `loadMore`, `refresh`; appends pages without duplicate `pool_id`s
- Pools tab supports pull-to-refresh, infinite scroll near bottom, and a Load more control

### #524  MO-009 — Validate pool/token selection
- `validatePoolAndToken` checks pool exists and that the deposit token matches the pool’s configured token before the mock signing step
- Deposit form also guards empty `poolId` / `token`

### #523  MO-008 — Validate deposit precision
- `parseAmountToUnits(amount, decimals)` rejects excess fractional digits, scientific notation, non-finite/zero values, and invalid decimals
- Uses pool `token_decimals` when present, otherwise Stellar default of 7
- Boundary unit tests in `apps/mobile/__tests__/usePoolDeposit.test.ts`

## Files touched
- `Backend/src/api/routes/pools.ts`
- `Backend/src/api/contracts.ts`
- `Backend/src/api/__tests__/routes.test.ts`
- `apps/mobile/utils/indexerClient.ts`
- `apps/mobile/hooks/usePool.ts`
- `apps/mobile/hooks/usePools.ts`
- `apps/mobile/hooks/usePoolDeposit.ts`
- `apps/mobile/components/PoolDepositForm.tsx`
- `apps/mobile/app/(tabs)/pools.tsx`
- `apps/mobile/app/pool/[id].tsx`
- `apps/mobile/__tests__/usePoolDeposit.test.ts`

## Test plan
- [ ] `GET /api/pools?limit=10&offset=0` returns `pools`, `total`, `has_more`
- [ ] `GET /api/pools/:id` still returns a single pool (or 404)
- [ ] Pool detail screen loads from indexer; unknown id shows not found
- [ ] Pools list loads more pages without duplicate cards; end-of-list state appears when `has_more` is false
- [ ] Deposit with wrong token / missing pool fails before success
- [ ] Deposit amounts with more fractional digits than token decimals are rejected
- [ ] Unit tests: `parseAmountToUnits` boundary cases pass