### PR TITLE
CT-035 & CT-036: complete daily index events and contract storage versioning

### DIFF
--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -1,0 +1,6 @@
+# Cargo build output
+target/
+
+# Soroban writes a JSON snapshot per test on every `cargo test` run. They are
+# regenerated deterministically and would otherwise land in every diff.
+test_snapshots/

--- a/packages/contracts/Cargo.lock
+++ b/packages/contracts/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -90,7 +90,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -143,7 +143,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
@@ -193,6 +193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,10 +208,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -222,14 +246,14 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -249,14 +273,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -281,6 +305,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -319,6 +352,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,13 +383,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
 ]
 
 [[package]]
@@ -358,7 +415,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -392,7 +449,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -405,7 +462,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -416,7 +473,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -427,14 +484,45 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "der"
@@ -452,7 +540,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -475,7 +562,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -484,10 +571,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -524,7 +621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -546,7 +643,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core",
  "serde",
@@ -557,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -569,7 +666,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -614,10 +711,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
+name = "fiat-crypto"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fnv"
@@ -627,21 +730,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -710,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -751,7 +854,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -802,7 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -829,14 +941,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.97"
+name = "jiff"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -858,14 +1022,21 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "kovara-index"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -875,9 +1046,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "macro-string"
@@ -887,20 +1058,20 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -908,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -920,14 +1091,14 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -982,6 +1153,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,7 +1189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1017,27 +1203,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1065,22 +1251,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1104,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "schemars"
@@ -1133,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1164,9 +1350,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1174,29 +1360,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1207,18 +1393,20 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.8.22",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -1227,14 +1415,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1244,8 +1432,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1254,15 +1442,15 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -1270,7 +1458,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -1282,27 +1470,27 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "25.0.1"
+version = "25.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7192e3a5551a7aeee90d2110b11b615798e81951fd8c8293c87ea7f88b0168f5"
+checksum = "4ade35a1b0ff1e1d441937e7bd9751ca1abf1f821de6dba20a97c3d2a9839487"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "soroban-env-common"
-version = "25.0.1"
+version = "25.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc49a80a68fc1005847308e63b9fce39874de731940b1807b721d472de3ff01"
+checksum = "b4b8536d2e618a1e8ee7d8fc62d0bd25a414ab6c6bd0c8beb8eb49cb0ca283dd"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1319,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "25.0.1"
+version = "25.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2334ba1cfe0a170ab744d96db0b4ca86934de9ff68187ceebc09dc342def55"
+checksum = "54672105913cdee84f9b724d907b0ee1fb5ef13274b631733f82d513b41bbbc9"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1329,16 +1517,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "25.0.1"
+version = "25.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43af5d53c57bc2f546e122adc0b1cca6f93942c718977379aa19ddd04f06fcec"
+checksum = "9dc699ee49eb479b10243e92141ce5055bce93370b15bbc288e3a04460522b11"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
@@ -1366,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "25.0.1"
+version = "25.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a989167512e3592d455b1e204d703cfe578a36672a77ed2f9e6f7e1bbfd9cc5c"
+checksum = "6bfa1fced23738aa5d7f0931f0021193824dd3902094b41aba93bd54e2490b64"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1376,28 +1564,28 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "25.3.1"
+version = "25.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca06e6c5029d1285e66219cb387a234224e26969ce8ad2bc2d5017e9395d63b"
+checksum = "d03e97dec49a6253fda7fd67acc2317501dfb795edb6c9df8fd3d6368d0f43b5"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
  "soroban-env-common",
  "soroban-env-host",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "soroban-sdk"
-version = "25.3.1"
+version = "25.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4502f2e018f238a4c5d3212d7d20ea6abcdc6e58babd63b642b693739db30fd1"
+checksum = "ac533d6e9e305219f2aea0d0dabf67ebc2318d397e2923172da4991d7e2caa99"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1419,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "25.3.1"
+version = "25.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca03e9cf61d241cb9afdd6ddf41f6c25698b3f566a875e7009ea799b89e2bf0a"
+checksum = "85096a9b56a5ba3e8b2c7baa8d66fd6a806799ed68c8f50ed7c3092f5d110268"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -1434,27 +1622,27 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "25.3.1"
+version = "25.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa02e07f507cc27406ae0834db4dcf309b78c4cc8776eb3b2d662d66e8859d25"
+checksum = "ddff27bf9f759efca36eef385a098b36392266e2604df756e1a70a4c45089f70"
 dependencies = [
  "base64",
  "sha2",
  "stellar-xdr",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser",
 ]
 
 [[package]]
 name = "soroban-spec-rust"
-version = "25.3.1"
+version = "25.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6835bb510763ef3fa5405e89036e3c8ea6ef5abe55fc52cfe9ac0e38be9d531c"
+checksum = "b7ccf8ffa328afd23b11792a31f96c97f261943467762eed45b46f7a46433dfc"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1462,8 +1650,8 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.117",
- "thiserror",
+ "syn 2.0.119",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1481,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -1572,9 +1760,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1587,7 +1786,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -1598,17 +1806,27 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1618,25 +1836,40 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1658,7 +1891,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1669,9 +1902,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1682,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1692,22 +1925,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -1770,7 +2003,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1781,7 +2014,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1810,46 +2043,46 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/packages/contracts/contracts/kovara-index/Cargo.toml
+++ b/packages/contracts/contracts/kovara-index/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "kovara-index"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/contracts/contracts/kovara-index/README.md
+++ b/packages/contracts/contracts/kovara-index/README.md
@@ -1,0 +1,104 @@
+# `kovara-index`
+
+Daily Kōvara Value Index (KVI) records — one per country, per day.
+
+Implements **CT-035** (complete daily index events) and **CT-036** (contract
+storage versioning). This crate is deliberately the minimum surface those two
+issues need; the rest of the index behaviour belongs to other issues and will
+extend it.
+
+## What is here, and what is not
+
+| Issue | Owns | State |
+|---|---|---|
+| CT-035 | The `DailyIndexUpdated` event and its fields | **This crate** |
+| CT-036 | Schema versioning and rejection of incompatible data | **This crate** |
+| CT-030 | Daily index storage semantics | Not implemented |
+| CT-031 | KVI rounding rules for `value` | Not implemented |
+| CT-032 | Deterministic aggregation producing `value` | Not implemented |
+| CT-033 | Rejection of duplicate index updates | Not implemented |
+| CT-034 | The authorization policy for who may update | Not implemented |
+
+`set_daily_index` therefore accepts a value some other component computed,
+requires only that the named updater signed for itself, and lets a later write
+replace an earlier one. Each of those is a named issue above. Guessing at
+their semantics now would only have to be undone.
+
+## Storage versioning policy (CT-036)
+
+Two mechanisms doing two different jobs.
+
+**The schema version is recorded at initialization**, and every operation
+checks it. A deployment initialized under one schema and then handed code
+expecting another fails with `IncompatibleSchema` rather than reading records
+it does not understand. Reads are guarded as well as writes — a bad read is
+the quieter failure, because it returns a plausible wrong number instead of an
+error.
+
+**Record keys embed the schema version.** `DailyIndex(1, "NG", d)` and
+`DailyIndex(2, "NG", d)` are different entries, so two schemas' data occupy
+disjoint keyspaces.
+
+That second part is what makes a future migration possible: v2 records can be
+written alongside v1 rather than on top, so a migration is resumable and a
+failed one leaves the original data intact.
+
+### Changing the schema
+
+1. Change the stored shape or the meaning of a key.
+2. Bump `SCHEMA_VERSION` **in the same commit**.
+3. Every existing deployment now rejects all operations until migrated. That
+   is the intended outcome — the alternative is decoding a v1 record as
+   though it were v2.
+
+Executing a migration is **out of scope here.** CT-036 asks for versioning and
+rejection, not a migration engine; the versioned keyspace is the precondition
+for one. A migration entry point belongs in its own issue, and it should read
+under the old schema version and write under the new one.
+
+### Inspecting a deployment
+
+```
+deployed_schema_version() -> Option<u32>   what this deployment was initialized at
+expected_schema_version() -> u32           what this build understands
+is_schema_compatible()    -> bool          whether they agree
+```
+
+Deployment tooling should call these rather than provoking an error to find
+out.
+
+## The daily index event (CT-035)
+
+`DailyIndexUpdated` carries every field the issue requires — country, date,
+value, basket version, source period, and updater — so a consumer can act on
+the event alone without a follow-up read.
+
+`country` and `date` are **topics**, because those are the two dimensions an
+indexer filters on. Everything else is in the data section.
+
+Two fields exist because consumers could not otherwise interpret the number:
+
+- **`basket_version`** — without it, a consumer cannot tell a real movement in
+  prices from a change in what is being measured. Zero is rejected, since zero
+  is what "no basket recorded" would look like and that is precisely the
+  ambiguity this removes.
+- **`source_period_start` / `source_period_end`** — the window the underlying
+  observations cover, which is not the same as the day the index is filed
+  under.
+
+`schema_version` rides along too, so a consumer can tell which storage schema
+produced a record — which matters while a migration is in progress and both
+schemas are briefly live.
+
+## Build and test
+
+```bash
+cd packages/contracts
+
+cargo test                                       # 23 tests
+cargo build --target wasm32v1-none --release     # -> target/wasm32v1-none/release/kovara_index.wasm
+```
+
+Use **`wasm32v1-none`**, not `wasm32-unknown-unknown`. Rust 1.82+ enables
+reference-types and multi-value on the latter, which the Soroban environment
+does not support; the build fails with an explicit error saying so.

--- a/packages/contracts/contracts/kovara-index/src/lib.rs
+++ b/packages/contracts/contracts/kovara-index/src/lib.rs
@@ -1,0 +1,310 @@
+#![no_std]
+//! `KovaraIndex` — daily Kōvara Value Index (KVI) records, one per country
+//! per day.
+//!
+//! This crate currently carries the minimum surface needed by **CT-035**
+//! (complete daily index events) and **CT-036** (contract storage
+//! versioning). The rest of the index behaviour is owned by other issues and
+//! will extend what is here rather than replace it:
+//!
+//! | Issue | Adds |
+//! |---|---|
+//! | CT-030 | Daily index storage semantics beyond the single record below |
+//! | CT-031 | KVI rounding rules for `value` |
+//! | CT-032 | Deterministic aggregation producing `value` |
+//! | CT-033 | Rejection of duplicate index updates |
+//! | CT-034 | The authorization policy for who may update |
+//!
+//! Deliberately **not** implemented here: rounding, aggregation, duplicate
+//! rejection, and the authorization policy. `set_daily_index` therefore
+//! accepts a value that some other component computed, requires only that the
+//! named updater signed for itself, and allows a later write to replace an
+//! earlier one. Each of those is a named issue above, and guessing at their
+//! semantics now would only have to be undone.
+//!
+//! # Storage versioning (CT-036)
+//!
+//! Two mechanisms, and they do different jobs.
+//!
+//! **The schema version is recorded at initialization** and every operation
+//! checks it. A contract deployed under one schema and then handed code
+//! expecting another fails with [`Error::IncompatibleSchema`] rather than
+//! reading records it does not understand. That is the "incompatible changes
+//! are rejected" half.
+//!
+//! **Record keys embed the schema version**, so `DailyIndex(1, "NG", d)` and
+//! `DailyIndex(2, "NG", d)` are different entries. That is the "storage keys
+//! are versioned" half, and it is what makes a future migration possible: v2
+//! records can be written alongside v1 rather than on top of them, so a
+//! migration is resumable and a failed one leaves the old data intact.
+//!
+//! Executing a migration is out of scope here — CT-036 asks for versioning
+//! and rejection, not a migration engine. The keyspace above is the
+//! precondition for one.
+
+use soroban_sdk::{
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, Env, Symbol,
+};
+
+#[cfg(test)]
+mod test;
+
+/// The storage schema this build of the contract understands.
+///
+/// Bump this in the same commit as any change to the shape of a stored value
+/// or to the meaning of a key. A deployment initialized under an older schema
+/// then rejects every operation until it is migrated, which is the intended
+/// outcome — the alternative is reading a v1 record as though it were v2.
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    /// `initialize` has already run.
+    AlreadyInitialized = 1,
+
+    /// The contract has not been initialized, so it has no schema version.
+    NotInitialized = 2,
+
+    /// The deployment's stored schema version does not match
+    /// [`SCHEMA_VERSION`]. The data must be migrated before this code can
+    /// safely operate on it.
+    IncompatibleSchema = 3,
+
+    /// `basket_version` was zero. Zero is reserved for "no basket recorded",
+    /// which is exactly the ambiguity CT-035 exists to remove.
+    InvalidBasketVersion = 4,
+
+    /// The source period ends before it starts.
+    InvalidSourcePeriod = 5,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Instance: the schema version this deployment was initialized at.
+    Schema,
+
+    /// Instance: the administrator address recorded at initialization.
+    Admin,
+
+    /// Persistent: `(schema_version, country, date)` → [`DailyIndex`].
+    ///
+    /// The schema version leads the key so that records written under
+    /// different schemas never collide.
+    DailyIndex(u32, Symbol, u64),
+}
+
+/// One country's index value for one day.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DailyIndex {
+    /// ISO country code the index covers.
+    pub country: Symbol,
+
+    /// The day this index describes, as days since the Unix epoch.
+    pub date: u64,
+
+    /// The index value, in the contract's fixed-point representation.
+    ///
+    /// CT-031 defines the rounding rules that produce this; CT-032 defines
+    /// the aggregation. This crate stores whatever it is given.
+    pub value: i128,
+
+    /// Which basket definition the value was computed against.
+    ///
+    /// Without this a consumer cannot tell a real movement in prices from a
+    /// change in what is being measured.
+    pub basket_version: u32,
+
+    /// Start of the period the underlying observations cover (Unix seconds).
+    pub source_period_start: u64,
+
+    /// End of the period the underlying observations cover (Unix seconds).
+    pub source_period_end: u64,
+
+    /// The address that submitted this record.
+    pub updater: Address,
+
+    /// The schema version in force when the record was written.
+    pub schema_version: u32,
+}
+
+/// Emitted whenever a daily index record is written (CT-035).
+///
+/// Carries every field CT-035 requires — country, date, value, basket,
+/// source period, updater — so a consumer can act on the event alone without
+/// a follow-up read. `country` and `date` are topics because those are the
+/// two dimensions an indexer filters on.
+///
+/// `schema_version` rides along so a consumer can tell which storage schema
+/// produced the record, which matters the moment a migration is in progress
+/// and both schemas are briefly live.
+#[contractevent]
+#[derive(Clone)]
+pub struct DailyIndexUpdated {
+    #[topic]
+    pub country: Symbol,
+
+    #[topic]
+    pub date: u64,
+
+    pub value: i128,
+    pub basket_version: u32,
+    pub source_period_start: u64,
+    pub source_period_end: u64,
+    pub updater: Address,
+    pub schema_version: u32,
+}
+
+#[contract]
+pub struct KovaraIndex;
+
+#[contractimpl]
+impl KovaraIndex {
+    /// Initialize the contract, recording the admin and the schema version.
+    ///
+    /// # Errors
+    /// * `AlreadyInitialized` — initialization has already happened
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Schema) {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::Schema, &SCHEMA_VERSION);
+
+        Ok(())
+    }
+
+    /// The schema version this deployment was initialized at.
+    ///
+    /// `None` before initialization. Deployment tooling uses this to decide
+    /// whether a migration is needed without having to provoke an error.
+    pub fn deployed_schema_version(env: Env) -> Option<u32> {
+        env.storage().instance().get(&DataKey::Schema)
+    }
+
+    /// The schema version this build of the contract understands.
+    pub fn expected_schema_version(_env: Env) -> u32 {
+        SCHEMA_VERSION
+    }
+
+    /// Whether this deployment's data is compatible with this build.
+    pub fn is_schema_compatible(env: Env) -> bool {
+        Self::require_compatible_schema(&env).is_ok()
+    }
+
+    /// The administrator recorded at initialization.
+    pub fn admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Admin)
+    }
+
+    /// Write a daily index record and emit [`DailyIndexUpdated`].
+    ///
+    /// The `updater` signs for itself. *Which* addresses are permitted to
+    /// update is CT-034's decision, not this function's — this establishes
+    /// only that the address named in the record and the event is the address
+    /// that actually authorized the call, so the `updater` field means
+    /// something.
+    ///
+    /// # Errors
+    /// * `NotInitialized` — the contract has no schema version yet
+    /// * `IncompatibleSchema` — stored schema differs from [`SCHEMA_VERSION`]
+    /// * `InvalidBasketVersion` — `basket_version` is zero
+    /// * `InvalidSourcePeriod` — the period ends before it starts
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_daily_index(
+        env: Env,
+        updater: Address,
+        country: Symbol,
+        date: u64,
+        value: i128,
+        basket_version: u32,
+        source_period_start: u64,
+        source_period_end: u64,
+    ) -> Result<(), Error> {
+        let schema_version = Self::require_compatible_schema(&env)?;
+
+        updater.require_auth();
+
+        // Only the two fields CT-035 introduces are validated here. Country,
+        // date and value validation belong to CT-004, CT-005 and CT-030.
+        if basket_version == 0 {
+            return Err(Error::InvalidBasketVersion);
+        }
+
+        if source_period_end < source_period_start {
+            return Err(Error::InvalidSourcePeriod);
+        }
+
+        let record = DailyIndex {
+            country: country.clone(),
+            date,
+            value,
+            basket_version,
+            source_period_start,
+            source_period_end,
+            updater: updater.clone(),
+            schema_version,
+        };
+
+        env.storage().persistent().set(
+            &DataKey::DailyIndex(schema_version, country.clone(), date),
+            &record,
+        );
+
+        DailyIndexUpdated {
+            country,
+            date,
+            value,
+            basket_version,
+            source_period_start,
+            source_period_end,
+            updater,
+            schema_version,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Read a daily index record.
+    ///
+    /// # Errors
+    /// * `NotInitialized` / `IncompatibleSchema` — as above. Reads are
+    ///   guarded too: returning a record decoded under the wrong schema is
+    ///   the failure mode this is meant to prevent.
+    pub fn get_daily_index(
+        env: Env,
+        country: Symbol,
+        date: u64,
+    ) -> Result<Option<DailyIndex>, Error> {
+        let schema_version = Self::require_compatible_schema(&env)?;
+
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&DataKey::DailyIndex(schema_version, country, date)))
+    }
+
+    /// Return the deployment's schema version, or fail if it is unusable.
+    fn require_compatible_schema(env: &Env) -> Result<u32, Error> {
+        let stored: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Schema)
+            .ok_or(Error::NotInitialized)?;
+
+        if stored != SCHEMA_VERSION {
+            return Err(Error::IncompatibleSchema);
+        }
+
+        Ok(stored)
+    }
+}

--- a/packages/contracts/contracts/kovara-index/src/test.rs
+++ b/packages/contracts/contracts/kovara-index/src/test.rs
@@ -1,0 +1,586 @@
+//! Tests for CT-035 (complete daily index events) and CT-036 (storage
+//! versioning).
+
+use crate::{
+    DailyIndex, DailyIndexUpdated, DataKey, Error, KovaraIndex, KovaraIndexClient, SCHEMA_VERSION,
+};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{symbol_short, vec, Address, Env, Event, IntoVal, Symbol};
+
+struct Fixture<'a> {
+    env: Env,
+    client: KovaraIndexClient<'a>,
+    contract_id: Address,
+    admin: Address,
+    updater: Address,
+}
+
+fn deploy() -> Fixture<'static> {
+    let env = Env::default();
+    let contract_id = env.register(KovaraIndex, ());
+    let client = KovaraIndexClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let updater = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    Fixture {
+        env,
+        client,
+        contract_id,
+        admin,
+        updater,
+    }
+}
+
+fn deploy_initialized() -> Fixture<'static> {
+    let f = deploy();
+    f.client.initialize(&f.admin);
+    f
+}
+
+const NG: Symbol = symbol_short!("NG");
+const DATE: u64 = 20_140;
+const VALUE: i128 = 1_234_567;
+const BASKET: u32 = 7;
+const PERIOD_START: u64 = 1_700_000_000;
+const PERIOD_END: u64 = 1_700_086_400;
+
+fn set_index(f: &Fixture) {
+    f.client.set_daily_index(
+        &f.updater,
+        &NG,
+        &DATE,
+        &VALUE,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+}
+
+// ── Initialization and schema versioning (CT-036) ────────────────────────
+
+#[test]
+fn a_fresh_deployment_has_no_schema_version() {
+    let f = deploy();
+
+    assert_eq!(f.client.deployed_schema_version(), None);
+    assert_eq!(f.client.expected_schema_version(), SCHEMA_VERSION);
+    assert!(!f.client.is_schema_compatible());
+}
+
+#[test]
+fn initialization_records_the_schema_version_and_admin() {
+    let f = deploy_initialized();
+
+    assert_eq!(f.client.deployed_schema_version(), Some(SCHEMA_VERSION));
+    assert_eq!(f.client.admin(), Some(f.admin.clone()));
+    assert!(f.client.is_schema_compatible());
+}
+
+#[test]
+fn initializing_twice_is_rejected() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client.try_initialize(&f.admin),
+        Err(Ok(Error::AlreadyInitialized))
+    );
+}
+
+/// Operations must not run against a contract with no recorded schema —
+/// there is nothing to check compatibility against.
+#[test]
+fn operations_are_rejected_before_initialization() {
+    let f = deploy();
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &f.updater,
+            &NG,
+            &DATE,
+            &VALUE,
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::NotInitialized))
+    );
+
+    assert_eq!(
+        f.client.try_get_daily_index(&NG, &DATE),
+        Err(Ok(Error::NotInitialized))
+    );
+}
+
+/// The core CT-036 requirement: a deployment whose stored schema does not
+/// match this build must be refused rather than operated on.
+#[test]
+fn an_incompatible_schema_is_rejected_for_writes() {
+    let f = deploy_initialized();
+
+    // Simulate data written by a future release.
+    f.env.as_contract(&f.contract_id, || {
+        f.env
+            .storage()
+            .instance()
+            .set(&DataKey::Schema, &(SCHEMA_VERSION + 1));
+    });
+
+    assert!(!f.client.is_schema_compatible());
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &f.updater,
+            &NG,
+            &DATE,
+            &VALUE,
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::IncompatibleSchema))
+    );
+}
+
+/// Reads are guarded too. Returning a record decoded under the wrong schema
+/// is precisely the failure this prevents, and it is the quieter half —
+/// a bad read produces a plausible wrong number rather than an error.
+#[test]
+fn an_incompatible_schema_is_rejected_for_reads() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    f.env.as_contract(&f.contract_id, || {
+        f.env
+            .storage()
+            .instance()
+            .set(&DataKey::Schema, &(SCHEMA_VERSION + 1));
+    });
+
+    assert_eq!(
+        f.client.try_get_daily_index(&NG, &DATE),
+        Err(Ok(Error::IncompatibleSchema))
+    );
+}
+
+/// An older stored schema is just as incompatible as a newer one — this
+/// build cannot know the shape of data it predates either.
+#[test]
+fn an_older_schema_is_also_rejected() {
+    let f = deploy_initialized();
+
+    f.env.as_contract(&f.contract_id, || {
+        f.env.storage().instance().set(&DataKey::Schema, &0u32);
+    });
+
+    assert_eq!(
+        f.client.try_get_daily_index(&NG, &DATE),
+        Err(Ok(Error::IncompatibleSchema))
+    );
+}
+
+/// Records are keyed by schema version, so two schemas' data occupy disjoint
+/// keyspaces. That is what lets a migration write v2 records without
+/// destroying v1, and it is why a failed migration is recoverable.
+#[test]
+fn records_under_different_schemas_do_not_collide() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    let other_schema = SCHEMA_VERSION + 1;
+
+    f.env.as_contract(&f.contract_id, || {
+        // A record written by a different schema, at the same country/date.
+        let foreign = DailyIndex {
+            country: NG,
+            date: DATE,
+            value: 999,
+            basket_version: 1,
+            source_period_start: PERIOD_START,
+            source_period_end: PERIOD_END,
+            updater: f.updater.clone(),
+            schema_version: other_schema,
+        };
+
+        f.env
+            .storage()
+            .persistent()
+            .set(&DataKey::DailyIndex(other_schema, NG, DATE), &foreign);
+
+        // The v1 record is untouched.
+        let ours: DailyIndex = f
+            .env
+            .storage()
+            .persistent()
+            .get(&DataKey::DailyIndex(SCHEMA_VERSION, NG, DATE))
+            .expect("v1 record still present");
+
+        assert_eq!(ours.value, VALUE);
+        assert_eq!(ours.schema_version, SCHEMA_VERSION);
+    });
+}
+
+#[test]
+fn stored_records_carry_the_schema_they_were_written_under() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    let record = f.client.get_daily_index(&NG, &DATE).unwrap();
+
+    assert_eq!(record.schema_version, SCHEMA_VERSION);
+}
+
+// ── Complete daily index events (CT-035) ─────────────────────────────────
+
+/// Build the event the contract is expected to have emitted, from the field
+/// values it was given.
+///
+/// Comparing against a constructed `DailyIndexUpdated` rather than poking at
+/// topics and data by hand means the assertion covers *every* field: if a
+/// field were dropped from the event, or emitted with the wrong value, this
+/// stops matching.
+fn expected_event(
+    f: &Fixture,
+    event: &DailyIndexUpdated,
+) -> soroban_sdk::Vec<(
+    Address,
+    soroban_sdk::Vec<soroban_sdk::Val>,
+    soroban_sdk::Val,
+)> {
+    vec![
+        &f.env,
+        (
+            f.contract_id.clone(),
+            event.topics(&f.env),
+            event.data(&f.env),
+        ),
+    ]
+}
+
+/// Events from the most recent invocation only — `Events::all()` does not
+/// accumulate across calls, so anything asserting on an event has to look
+/// immediately after the call that emitted it.
+fn emitted_count(f: &Fixture) -> usize {
+    f.env.events().all().events().len()
+}
+
+/// The acceptance criterion: events include country, date, value, basket,
+/// source period, and updater.
+#[test]
+fn the_event_carries_every_required_field() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    let expected = DailyIndexUpdated {
+        country: NG,
+        date: DATE,
+        value: VALUE,
+        basket_version: BASKET,
+        source_period_start: PERIOD_START,
+        source_period_end: PERIOD_END,
+        updater: f.updater.clone(),
+        schema_version: SCHEMA_VERSION,
+    };
+
+    assert_eq!(f.env.events().all(), expected_event(&f, &expected));
+}
+
+/// Country and date are topics so an indexer can subscribe to one country
+/// without decoding every event body.
+#[test]
+fn country_and_date_are_indexable_topics() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    let event = DailyIndexUpdated {
+        country: NG,
+        date: DATE,
+        value: VALUE,
+        basket_version: BASKET,
+        source_period_start: PERIOD_START,
+        source_period_end: PERIOD_END,
+        updater: f.updater.clone(),
+        schema_version: SCHEMA_VERSION,
+    };
+
+    let topics = event.topics(&f.env);
+
+    let country_topic: soroban_sdk::Val = NG.into_val(&f.env);
+    let date_topic: soroban_sdk::Val = DATE.into_val(&f.env);
+    let value_val: soroban_sdk::Val = VALUE.into_val(&f.env);
+
+    assert!(
+        topics.contains(country_topic),
+        "country should be a topic: {topics:?}"
+    );
+    assert!(
+        topics.contains(date_topic),
+        "date should be a topic: {topics:?}"
+    );
+
+    // And the value is not a topic — it belongs in the data section.
+    assert!(!topics.contains(value_val));
+}
+
+/// The event must describe the record that was actually stored — a consumer
+/// acting on the event alone must not diverge from one that reads state.
+#[test]
+fn the_event_matches_the_stored_record() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    // Capture the event before any further call: the read below would
+    // otherwise replace it, since events do not accumulate.
+    let emitted = f.env.events().all();
+
+    let stored = f.client.get_daily_index(&NG, &DATE).unwrap();
+
+    let from_storage = DailyIndexUpdated {
+        country: stored.country.clone(),
+        date: stored.date,
+        value: stored.value,
+        basket_version: stored.basket_version,
+        source_period_start: stored.source_period_start,
+        source_period_end: stored.source_period_end,
+        updater: stored.updater.clone(),
+        schema_version: stored.schema_version,
+    };
+
+    assert_eq!(emitted, expected_event(&f, &from_storage));
+}
+
+/// Every accepted update emits exactly one event — not zero, and not a
+/// duplicate.
+#[test]
+fn each_update_emits_exactly_one_event() {
+    let f = deploy_initialized();
+
+    set_index(&f);
+    assert_eq!(emitted_count(&f), 1);
+
+    f.client.set_daily_index(
+        &f.updater,
+        &symbol_short!("KE"),
+        &DATE,
+        &VALUE,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    assert_eq!(emitted_count(&f), 1);
+}
+
+/// A rejected update must emit nothing — an event for a write that did not
+/// happen is worse than no event.
+#[test]
+fn a_rejected_update_emits_no_event() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &f.updater,
+            &NG,
+            &DATE,
+            &VALUE,
+            &0u32, // invalid basket
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::InvalidBasketVersion))
+    );
+
+    assert_eq!(emitted_count(&f), 0);
+}
+
+// ── Field validation ─────────────────────────────────────────────────────
+
+/// Zero is reserved for "no basket recorded", which is the ambiguity CT-035
+/// exists to remove — so it cannot also be a valid basket.
+#[test]
+fn a_zero_basket_version_is_rejected() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &f.updater,
+            &NG,
+            &DATE,
+            &VALUE,
+            &0u32,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::InvalidBasketVersion))
+    );
+}
+
+#[test]
+fn a_backwards_source_period_is_rejected() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &f.updater,
+            &NG,
+            &DATE,
+            &VALUE,
+            &BASKET,
+            &PERIOD_END,
+            &PERIOD_START
+        ),
+        Err(Ok(Error::InvalidSourcePeriod))
+    );
+}
+
+/// A period covering a single instant is legitimate — a spot observation.
+#[test]
+fn an_instantaneous_source_period_is_accepted() {
+    let f = deploy_initialized();
+
+    f.client.set_daily_index(
+        &f.updater,
+        &NG,
+        &DATE,
+        &VALUE,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_START,
+    );
+
+    let record = f.client.get_daily_index(&NG, &DATE).unwrap();
+
+    assert_eq!(record.source_period_start, record.source_period_end);
+}
+
+/// A rejected write must leave storage untouched.
+#[test]
+fn a_rejected_update_stores_nothing() {
+    let f = deploy_initialized();
+
+    assert!(f
+        .client
+        .try_set_daily_index(
+            &f.updater,
+            &NG,
+            &DATE,
+            &VALUE,
+            &0u32,
+            &PERIOD_START,
+            &PERIOD_END
+        )
+        .is_err());
+
+    assert_eq!(f.client.get_daily_index(&NG, &DATE), None);
+}
+
+// ── Storage round-trip ───────────────────────────────────────────────────
+
+#[test]
+fn a_record_round_trips() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    let record = f.client.get_daily_index(&NG, &DATE).unwrap();
+
+    assert_eq!(
+        record,
+        DailyIndex {
+            country: NG,
+            date: DATE,
+            value: VALUE,
+            basket_version: BASKET,
+            source_period_start: PERIOD_START,
+            source_period_end: PERIOD_END,
+            updater: f.updater.clone(),
+            schema_version: SCHEMA_VERSION,
+        }
+    );
+}
+
+#[test]
+fn an_unknown_country_or_date_reads_as_none() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    assert_eq!(f.client.get_daily_index(&symbol_short!("ZZ"), &DATE), None);
+    assert_eq!(f.client.get_daily_index(&NG, &(DATE + 1)), None);
+}
+
+#[test]
+fn records_are_kept_per_country_and_per_date() {
+    let f = deploy_initialized();
+
+    f.client.set_daily_index(
+        &f.updater,
+        &NG,
+        &DATE,
+        &100,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    f.client.set_daily_index(
+        &f.updater,
+        &symbol_short!("KE"),
+        &DATE,
+        &200,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    f.client.set_daily_index(
+        &f.updater,
+        &NG,
+        &(DATE + 1),
+        &300,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(f.client.get_daily_index(&NG, &DATE).unwrap().value, 100);
+    assert_eq!(
+        f.client
+            .get_daily_index(&symbol_short!("KE"), &DATE)
+            .unwrap()
+            .value,
+        200
+    );
+    assert_eq!(
+        f.client.get_daily_index(&NG, &(DATE + 1)).unwrap().value,
+        300
+    );
+}
+
+/// Negative values are storable. Whether the index may go negative is CT-031
+/// and CT-032's decision; this crate must not pre-empt it by rejecting them.
+#[test]
+fn a_negative_value_is_stored_as_given() {
+    let f = deploy_initialized();
+
+    f.client.set_daily_index(
+        &f.updater,
+        &NG,
+        &DATE,
+        &-42,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(f.client.get_daily_index(&NG, &DATE).unwrap().value, -42);
+}
+
+/// Authorization *policy* is CT-034's. What this pins is narrower and still
+/// necessary: the address recorded as `updater` is the address that signed,
+/// so the field means something.
+#[test]
+#[should_panic(expected = "Unauthorized function call for address")]
+fn an_unsigned_update_is_rejected_by_the_host() {
+    let f = deploy_initialized();
+
+    f.env.set_auths(&[]);
+
+    set_index(&f);
+}


### PR DESCRIPTION
Closes #510
Closes #511

Implements CT-035 (complete daily index events) and CT-036 (contract storage versioning).

---

## First: the contract layer does not exist

There is no Rust anywhere on `main` — `find -name "*.rs"` returns nothing.

The README documents `packages/contracts/` with `price_vault.rs`, `kovara_index.rs`, `sentinel_pool.rs` and `flow_rewards.rs`, but commit `df34b5d` ("fixes", 24 Aug) removed that directory while repurposing the repository. **CT-001, "Create the Soroban workspace", is #476 and still unassigned**, and nothing in the CT-001..CT-040 series has landed.

Neither of my two issues can be implemented against nothing, so this adds the workspace and the minimum `KovaraIndex` they need — and nothing beyond it.

### Scoping, so this does not collide with anyone

| Issue | Assignee | Owns | In this PR? |
|---|---|---|---|
| CT-030 | @MatanOga01 | Daily index storage semantics | No |
| CT-031 | @MatanOga01 | KVI rounding rules | No |
| CT-032 | @MatanOga01 | Deterministic aggregation | No |
| CT-033 | @MatanOga01 | Duplicate update rejection | No |
| CT-034 | @ThatCodeBabe | Authorization policy | No |
| **CT-035** | @Cybermaxi7 | The daily index event | **Yes** |
| **CT-036** | @Cybermaxi7 | Storage versioning | **Yes** |

`set_daily_index` therefore accepts a value that some other component computed, requires only that the named updater signed for itself, and lets a later write replace an earlier one. Every one of those is a named issue above — guessing at their semantics now would only have to be undone. The crate README carries the same table so the next person reading the code knows what is deliberately missing.

### Rebased onto #575

PR #575 merged while this was in progress, so `packages/contracts/` now exists upstream. This branch is rebased onto it and the diff is **only** the `kovara-index` crate — the workspace `Cargo.toml` I had written turned out byte-identical to the merged one (same `contracts/*` glob, same `soroban-sdk = "25"`, same profiles), so it dropped out of the diff entirely. The glob is what made that clean: neither PR had to edit a member list the other also edits.

---

## CT-036 — storage versioning (#511)

> *Acceptance: storage keys are versioned and incompatible changes are rejected/tested.*

Two mechanisms, doing two different jobs.

**The schema version is recorded at initialization**, and every operation checks it. A deployment initialized under one schema and then handed code expecting another fails with `IncompatibleSchema` rather than reading records it does not understand.

**Reads are guarded as well as writes.** A bad read is the quieter failure — it hands back a plausible wrong number instead of an error — so it is the one worth guarding hardest. There is a test for each direction.

**Record keys embed the schema version.** `DailyIndex(1, "NG", d)` and `DailyIndex(2, "NG", d)` are distinct entries, so two schemas' data occupy disjoint keyspaces.

That second part is what makes a future migration possible at all: v2 records can be written *alongside* v1 rather than on top, so a migration is resumable and a failed one leaves the original data intact.

**Executing a migration is deliberately out of scope.** CT-036 asks for versioning and rejection, not a migration engine. The versioned keyspace is the precondition for one, and the README states the policy for changing a schema — bump `SCHEMA_VERSION` in the same commit as the shape change, and accept that existing deployments then reject everything until migrated. That is the intended outcome; the alternative is decoding a v1 record as though it were v2.

`deployed_schema_version()`, `expected_schema_version()` and `is_schema_compatible()` let deployment tooling ask the question rather than provoke an error to find the answer.

## CT-035 — complete daily index events (#510)

> *Acceptance: events include country, date, value, basket, source period, and updater.*

`DailyIndexUpdated` carries all six, so a consumer can act on the event alone without a follow-up read.

`country` and `date` are **topics** — those are the two dimensions an indexer filters on. Everything else sits in the data section.

Two fields exist because a consumer cannot otherwise interpret the number, which is exactly what the issue's summary asks for:

- **`basket_version`** — without it there is no way to distinguish a real movement in prices from a change in *what is being measured*. Zero is rejected: zero is what "no basket recorded" would look like, and that ambiguity is the thing this field exists to remove.
- **`source_period_start` / `source_period_end`** — the window the underlying observations cover, which is not the same as the day the index is filed under.

`schema_version` is emitted too, which ties the two issues together: a consumer can tell which storage schema produced a record. That matters precisely while a migration is in progress and both schemas are briefly live.

---

## Tests — 23, all passing

**CT-036:** fresh deployment has no schema; initialization records it; double initialization rejected; operations rejected before initialization; a newer stored schema rejected for writes **and** for reads; an older schema equally rejected; records under different schemas do not collide; stored records carry the schema they were written under.

**CT-035:** the event carries every required field — asserted by comparing the emitted event against a `DailyIndexUpdated` built from the expected values, so a dropped or wrong field breaks the assertion rather than slipping through a partial check; country and date are topics and value is not; **the event matches the stored record**, so an event-driven consumer cannot diverge from one that reads state; each accepted update emits exactly one event; a rejected update emits none and stores nothing.

**Validation and round-trip:** zero basket rejected, backwards source period rejected, an instantaneous period accepted (a spot observation is legitimate), negative values stored as given — whether the index may go negative is CT-031/CT-032's call and this crate must not pre-empt it — per-country and per-date isolation, unknown keys read as `None`, and an unsigned update rejected by the host.

One thing worth recording because it cost time: **`Events::all()` returns the most recent invocation's events only — it does not accumulate.** Two tests initially asserted against a cumulative log and failed; they now capture events immediately after the emitting call, and the helper says so.

## Verification

```
cargo test  -p kovara-index                                 23 passed, 0 failed
cargo build -p kovara-index --target wasm32v1-none --release   kovara_index.wasm, 14977 bytes
cargo fmt   -p kovara-index -- --check                      clean
cargo clippy -p kovara-index --all-targets                  no warnings
```

Build for **`wasm32v1-none`**, not `wasm32-unknown-unknown`. Rust 1.82+ enables reference-types and multi-value on the latter, which the Soroban environment rejects outright with an explicit error.

`test_snapshots/` is gitignored via a package-local `.gitignore` — Soroban writes one JSON file per test on every run, and they would otherwise land in every diff. I kept it package-local rather than editing the root `.gitignore`.

### Why `-p kovara-index` and not the whole workspace

**Because the workspace does not build.** The `Kovara-contracts` crate merged in #575 does not compile, so a plain `cargo test` at `packages/contracts/` fails before reaching anything here. That is pre-existing and unrelated to this PR — but it means the per-package flag is the only way to verify anything right now, and I would rather say so than quietly use it.

I spent a while trying to repair it and backed out, because the damage is structural rather than a few typos. The precise diagnosis, in case it is useful:

**`contracts/linkora-contracts/src/test.rs` is a triple-concatenation.** The import block and the `setup_token` / `make_token` / `setup_contract` helpers each appear **three times**, and many test functions are duplicated along with them (`test_set_and_get_profile`, `test_get_following_second_page`, `test_get_posts_by_author_offset_beyond_end`, and more).

**Five places leave the file unparseable**, each one a function body that was truncated or overwritten:

| Location | What is wrong |
|---|---|
| `test_set_same_username_twice_for_same_user_is_idempotent` | `assert_eq!(` never closed |
| `test_proposal_sign_transitions_to_executed` | `assert_eq!(` never closed; a like-post test's body pasted into it |
| `test_get_pool_nonexistent_returns_none` | declared with no body — this is what swallows every following test into its scope |
| `test_profile_count_unchanged_after_multiple_updates` | declared with no body |
| `test_operations_succeed_after_initialize` | comment only, no body; absorbs `test_event_sequence_post_like_tip` and its `#[test]` |

**And `src/lib.rs` has two genuine compile errors** underneath all that, which only become visible once the test file parses:

```
error[E0081]: discriminant value `43` assigned more than once
    InvalidWasmHash = 43,   // collides with TreasuryCannotBeContract = 43

error[E0382]: use of moved value: `creator_token`
    creator_token is moved into Profile, then used again by ProfileSetEvent
```

Both of those are one-line fixes (`= 45`, and a `.clone()`). The test file is not — deciding which of three copies of each duplicated test is canonical is the author's call, not mine, so I have left all of it untouched. Happy to open a separate PR for the two `lib.rs` errors if that helps.

## Two things for the maintainers

**Every Rust step in `.github/workflows/` is commented out**, so CI will not build or test any of this. That is not hypothetical: it is exactly how #575 merged in a state where the crate does not compile. A job running `cargo test` and `cargo build --target wasm32v1-none --release` under `packages/contracts` would have caught it, and is worth uncommenting before the CT series starts landing in volume. Happy to open that separately.

**The README still documents the deleted layout** — `packages/contracts/src/price_vault.rs` and siblings, which do not exist and do not match either this PR's or #575's structure. Worth correcting once the workspace shape settles; I have not touched it here since #575 also edits that area.
