### PR TITLE
Clarify SentinelPool scope for issue 493

### DIFF
--- a/docs/issue-493-maintainer-note.md
+++ b/docs/issue-493-maintainer-note.md
@@ -1,0 +1,14 @@
+# Issue 493 maintainer note
+
+The requested change describes a bounded appeal path for irreversible SentinelPool
+slashes. I inspected this branch and the current contract workspace, but there is
+no SentinelPool contract, slash state machine, verifier-slashing entrypoint, or
+dispute model present to extend. The existing `kovara-index` contract only stores
+daily index records and has sentinel authorization for index updates; adding an
+appeal mechanism there would change the wrong contract and could weaken unrelated
+authorization guarantees.
+
+No contract behavior was changed in this PR. Please point the contributor to the
+branch or package that owns SentinelPool slashing, and specify the slash record,
+appeal authority, deadline, and reversal semantics. Once that scope is available,
+the bounded appeal and regression tests can be implemented safely.


### PR DESCRIPTION
Closes #493\n\nThe requested issue concerns a bounded appeal path for SentinelPool slashes. The checked-out repository contains no SentinelPool contract, slashing entrypoint, slash state, or dispute model. Its existing sentinel code belongs to kovara-index daily index authorization.\n\nThis PR documents the scope mismatch and asks the maintainer to identify the owning package and define appeal authority, deadline, slash record, and reversal semantics. No unrelated contract authorization was changed.