### PR TITLE
fix(contract): prevent self-verification

### DIFF
--- a/packages/contracts/contracts/linkora-contracts/src/lib.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/lib.rs
@@ -80,6 +80,7 @@ pub enum ContractError {
     TreasuryCannotBeContract = 43,
     NoOpFeeUpdate = 44,
     InvalidWasmHash = 43,
+    CannotLikeOwnPost = 45,
 }
 
 // ── Instance-storage key constants (small scalars, not contracttype) ──────────
@@ -895,6 +896,11 @@ impl KovaraContract {
             .unwrap_or_else(|| {
                 panic_with_error!(&env, ContractError::PostNotFound);
             });
+
+        if post.author == user {
+            panic_with_error!(&env, ContractError::CannotLikeOwnPost);
+        }
+
         post.like_count += 1;
         env.storage().persistent().set(&post_key, &post);
         Self::bump(&env, &post_key);

--- a/packages/contracts/contracts/linkora-contracts/src/test.rs
+++ b/packages/contracts/contracts/linkora-contracts/src/test.rs
@@ -921,6 +921,19 @@ fn test_like_post() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #45)")]
+fn test_like_own_post_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup_contract(&env);
+
+    let author = Address::generate(&env);
+    let post_id = client.create_post(&author, &String::from_str(&env, "Like test"));
+
+    client.like_post(&author, &post_id);
+}
+
+#[test]
 fn test_like_post_emits_event_on_first_like() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #489 

This PR addresses issue CT-014 by preventing contributors from verifying (liking) their own submissions (posts). 

### Changes
- Added a `CannotLikeOwnPost = 45` error to the `ContractError` enum in `linkora-contracts`.
- Updated `like_post` function logic in `lib.rs` to verify ownership and panic with `CannotLikeOwnPost` if the `user` is the `author` of the post. This ensures that self-votes fail gracefully without state mutation.
- Added a new test `test_like_own_post_panics` in `test.rs` to verify that the contract properly halts when an author attempts to self-verify.

### Acceptance Criteria
- [x] Submission ownership is checked
- [x] Self-votes fail without state mutation