### PR TITLE
CT-015: define SentinelPool quorum, tie, and abstention semantics

### DIFF
--- a/packages/contracts/contracts/sentinel-pool/Cargo.toml
+++ b/packages/contracts/contracts/sentinel-pool/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sentinel-pool"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# CT-015 is design-only: it defines and tests the weighted quorum/tie/
+# abstention resolution rule in isolation, before any staking, vote-casting,
+# or on-chain wiring exists (those are separate, not-yet-filed issues; see
+# README.md). There is deliberately no dependency on `soroban-sdk` and no
+# `#[contract]` here yet — `resolve()` is a plain, std, unit-testable
+# function so the semantics can be reviewed and pinned down on their own
+# merits. Wiring it into an actual Soroban contract (storage, `Address`,
+# staking, `vote`/`resolve` entry points, slashing) is future work that
+# will depend on this crate rather than duplicate it.
+
+[lib]
+crate-type = ["rlib"]

--- a/packages/contracts/contracts/sentinel-pool/README.md
+++ b/packages/contracts/contracts/sentinel-pool/README.md
@@ -1,0 +1,47 @@
+# `sentinel-pool`
+
+Weighted quorum, tie, and abstention resolution for `SentinelPool`.
+
+Implements **CT-015** (define quorum and ties) only. The rest of
+`SentinelPool` — staking, the `stake` / `vote` / `unstake` entry points,
+on-chain storage, and slashing (all described in the workspace-level
+`packages/contracts/README.md`) — is not implemented here and belongs to
+future, not-yet-filed issues.
+
+## What is here, and what is not
+
+| Concern | Owns | State |
+|---|---|---|
+| Quorum denominator (total pool weight vs. participating weight) | `resolve()` | **This crate** |
+| Tie resolution | `resolve()` | **This crate** |
+| Abstention semantics | `resolve()` | **This crate** |
+| Staking, `stake`/`vote`/`unstake`, storage layout | — | Not implemented |
+| Slashing | — | Not implemented |
+| Cross-contract calls into `FlowRewards` | — | Not implemented |
+
+`resolve()` is a plain function: it takes the votes cast on a submission and
+the pool's total weight as arguments, and returns a `Resolution`. It reads
+and writes no contract state, and has no dependency on `soroban-sdk` — see
+the module docs in `src/lib.rs` for why, and for the full rationale behind
+each rule. The short version:
+
+- **Quorum is measured against the whole pool's staked weight**, not just
+  the weight of whoever voted — otherwise a small, fast-moving minority
+  could satisfy "quorum" against itself.
+- **Ties resolve to `Rejected`** (this includes the `0`-`Approve`-weight,
+  `0`-`Reject`-weight case where everyone abstains) — a submission needs an
+  actual majority in favor, not just the absence of a majority against.
+- **Abstentions count toward reaching quorum but not toward the tally** —
+  the standard convention: showing up counts as participation, but doesn't
+  push the decision either way.
+
+## Tests
+
+`src/test.rs` exhaustively covers the three areas above plus the defensive
+preconditions `resolve()` enforces (duplicate voters, zero-weight votes,
+vote weight exceeding the stated pool total, a zero pool total, and
+arithmetic overflow) — run with:
+
+```
+cargo test -p sentinel-pool
+```

--- a/packages/contracts/contracts/sentinel-pool/src/lib.rs
+++ b/packages/contracts/contracts/sentinel-pool/src/lib.rs
@@ -1,0 +1,242 @@
+//! `sentinel-pool` — weighted quorum, tie, and abstention semantics for
+//! `SentinelPool` (CT-015).
+//!
+//! `SentinelPool` (per the workspace README) lets verifiers stake to gain
+//! voting weight and cast `Approve` / `Reject` votes on a submission before
+//! it resolves. What was previously **unspecified** — and is the entire
+//! scope of this issue — is: what counts in the quorum denominator, how a
+//! tie resolves, and what an abstention does to both. This crate answers
+//! those three questions with one function, [`resolve`], and pins the
+//! answer down with an exhaustive test suite in `src/test.rs`.
+//!
+//! | Concern | Answered here | Left to a future issue |
+//! |---|---|---|
+//! | Quorum denominator | ✅ total pool weight, not just voters | — |
+//! | Tie handling | ✅ ties resolve to `Rejected` | — |
+//! | Abstention semantics | ✅ counts for quorum, not for the tally | — |
+//! | Staking / vote casting / storage | Not implemented | Contract-wiring issue |
+//! | Slashing | Not implemented | Contract-wiring issue |
+//!
+//! Deliberately **not implemented here**: staking, the `stake` / `vote` /
+//! `unstake` entry points, storage layout, and slashing. `resolve` is a
+//! pure function that takes the votes and the pool's total weight as
+//! arguments — it does not read or write any contract state. Wiring this
+//! into an actual `#[contract]` (an `Address`-keyed `Vote` store, a
+//! `resolve(env, submission_id)` entry point, cross-contract calls into
+//! `FlowRewards`) is later work that depends on this crate rather than
+//! re-deriving these rules.
+//!
+//! # The quorum denominator
+//!
+//! Quorum is measured against **the total weight of the pool** (every
+//! staked verifier, whether or not they voted on this particular
+//! submission) — not against the weight of whoever happened to show up.
+//!
+//! This is the one design choice worth arguing for explicitly: a
+//! participation-only denominator ("quorum = X% of the votes that were
+//! cast") is trivially satisfied by a handful of colluding or simply fast
+//! verifiers casting votes before anyone else notices the submission —
+//! the quorum requirement stops doing any work. Measuring against the
+//! whole pool means an attacker needs actual weight, not just speed, to
+//! force a resolution.
+//!
+//! [`QUORUM_NUMERATOR`] / [`QUORUM_DENOMINATOR`] express the threshold as
+//! a fraction of total pool weight (currently `1/2`, i.e. votes must
+//! represent at least half the pool's total staked weight before a
+//! submission resolves at all). Below that, [`resolve`] returns
+//! [`Resolution::NoQuorum`] — the submission is neither approved nor
+//! rejected, it simply isn't decided yet.
+//!
+//! # Ties
+//!
+//! When quorum is met and `approve_weight == reject_weight` exactly (this
+//! includes the `0 == 0` case — see Abstentions below), [`resolve`] returns
+//! [`Resolution::Rejected`].
+//!
+//! The rule is fail-closed on purpose: `SentinelPool` verifies data that
+//! feeds a financial index (`KovaraIndex`). A submission should need an
+//! actual, positive majority in its favor to be treated as verified;
+//! anything that isn't a clear majority — a tie, or a quorum made up
+//! entirely of abstentions — defaults to `Rejected` rather than `Approved`.
+//! The failure mode of wrongly rejecting a good submission (resubmit) is
+//! far cheaper than the failure mode of wrongly approving a bad one (bad
+//! data enters the index).
+//!
+//! # Abstentions
+//!
+//! [`Verdict::Abstain`] counts its weight toward the quorum denominator's
+//! numerator (an abstaining verifier still *showed up*, so their weight
+//! counts as participation) but contributes to **neither**
+//! `approve_weight` nor `reject_weight`. A pool where everyone abstains
+//! reaches quorum (if their combined weight is enough) but resolves to
+//! `Rejected` by the tie rule above, since `approve_weight` and
+//! `reject_weight` are both `0`.
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use core::cmp::Ordering;
+
+#[cfg(test)]
+mod test;
+
+/// A single verifier's vote on a submission.
+///
+/// `V` is left generic (rather than fixed to `soroban_sdk::Address`) since
+/// this crate has no dependency on `soroban-sdk` — see the module docs for
+/// why. The eventual contract wiring can call [`resolve`] with `Address`
+/// directly, since the only requirement is [`PartialEq`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Vote<V> {
+    /// Identifies the verifier who cast this vote. Only used to detect
+    /// duplicate votes from the same verifier — [`resolve`] never inspects
+    /// it otherwise.
+    pub verifier: V,
+
+    /// This verifier's voting weight (their staked amount at the time of
+    /// voting). Must be greater than zero — see [`QuorumError::ZeroWeightVote`].
+    pub weight: u128,
+
+    /// What this verifier voted.
+    pub verdict: Verdict,
+}
+
+/// A verifier's verdict on a submission.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    Approve,
+    Reject,
+    /// Participates toward quorum but not toward the approve/reject tally.
+    /// See the module-level "Abstentions" section.
+    Abstain,
+}
+
+/// The outcome of resolving a submission's votes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Resolution {
+    /// Quorum was met and `approve_weight` strictly exceeded `reject_weight`.
+    Approved,
+    /// Quorum was met, but `approve_weight` did not strictly exceed
+    /// `reject_weight` — this covers both a genuine tie and the case where
+    /// `Reject` weight led outright.
+    Rejected,
+    /// Combined `Approve` + `Reject` + `Abstain` weight did not reach
+    /// [`QUORUM_NUMERATOR`] / [`QUORUM_DENOMINATOR`] of `total_pool_weight`.
+    /// The submission is undecided, not rejected.
+    NoQuorum,
+}
+
+/// Preconditions [`resolve`] enforces on its inputs. These are guardrails
+/// against a misbehaving caller (e.g. a future contract layer with a bug
+/// in how it assembles the vote list) — [`resolve`] itself never produces
+/// a state that would trigger one of these from valid input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuorumError {
+    /// The same verifier appears more than once in the vote list.
+    DuplicateVoter,
+    /// A vote was cast with `weight == 0`. A verifier with no stake has no
+    /// voting weight and should not be able to cast a vote at all.
+    ZeroWeightVote,
+    /// `total_pool_weight` was `0`. Quorum is undefined against an empty
+    /// pool — there is no "half of nothing" to reach.
+    ZeroTotalPoolWeight,
+    /// The votes' combined weight exceeds `total_pool_weight`. This can
+    /// only happen if the caller passed a `total_pool_weight` that does
+    /// not actually reflect every voter's registered stake.
+    VoteExceedsPoolWeight,
+    /// A weight sum overflowed `u128`. Not reachable with realistic stake
+    /// amounts (Stellar balances are bounded well below `u128::MAX`), but
+    /// checked rather than assumed.
+    WeightOverflow,
+}
+
+/// Numerator of the quorum threshold, as a fraction of `total_pool_weight`.
+pub const QUORUM_NUMERATOR: u128 = 1;
+/// Denominator of the quorum threshold. `QUORUM_NUMERATOR` / `QUORUM_DENOMINATOR`
+/// = `1/2`: at least half of the pool's total weight must participate
+/// (`Approve` + `Reject` + `Abstain`) before a submission resolves.
+pub const QUORUM_DENOMINATOR: u128 = 2;
+
+/// Resolve a submission's votes into an [`Resolution`].
+///
+/// `votes` is every vote cast on the submission; `total_pool_weight` is the
+/// combined staked weight of every verifier registered in the pool at
+/// resolution time (not just those in `votes`) — see the module-level
+/// "quorum denominator" section for why the two are different.
+///
+/// Returns `Err` if `votes` or `total_pool_weight` violate one of the
+/// [`QuorumError`] preconditions; otherwise returns the [`Resolution`].
+pub fn resolve<V: PartialEq>(
+    votes: &[Vote<V>],
+    total_pool_weight: u128,
+) -> Result<Resolution, QuorumError> {
+    if total_pool_weight == 0 {
+        return Err(QuorumError::ZeroTotalPoolWeight);
+    }
+
+    let mut approve_weight: u128 = 0;
+    let mut reject_weight: u128 = 0;
+    let mut participating_weight: u128 = 0;
+
+    for (i, vote) in votes.iter().enumerate() {
+        if vote.weight == 0 {
+            return Err(QuorumError::ZeroWeightVote);
+        }
+
+        // O(n^2) duplicate check is fine here: a verifier pool's vote list
+        // per submission is small (bounded by however many verifiers the
+        // pool has), and this only runs off-chain / in a resolve call, not
+        // in a hot loop.
+        for earlier in &votes[..i] {
+            if earlier.verifier == vote.verifier {
+                return Err(QuorumError::DuplicateVoter);
+            }
+        }
+
+        participating_weight = participating_weight
+            .checked_add(vote.weight)
+            .ok_or(QuorumError::WeightOverflow)?;
+
+        if participating_weight > total_pool_weight {
+            return Err(QuorumError::VoteExceedsPoolWeight);
+        }
+
+        match vote.verdict {
+            Verdict::Approve => {
+                approve_weight = approve_weight
+                    .checked_add(vote.weight)
+                    .ok_or(QuorumError::WeightOverflow)?;
+            }
+            Verdict::Reject => {
+                reject_weight = reject_weight
+                    .checked_add(vote.weight)
+                    .ok_or(QuorumError::WeightOverflow)?;
+            }
+            Verdict::Abstain => {
+                // Counts toward `participating_weight` (already added
+                // above) but not toward either tally.
+            }
+        }
+    }
+
+    // participating_weight / total_pool_weight >= QUORUM_NUMERATOR / QUORUM_DENOMINATOR
+    // rearranged to avoid division: participating_weight * QUORUM_DENOMINATOR >= total_pool_weight * QUORUM_NUMERATOR
+    let lhs = participating_weight
+        .checked_mul(QUORUM_DENOMINATOR)
+        .ok_or(QuorumError::WeightOverflow)?;
+    let rhs = total_pool_weight
+        .checked_mul(QUORUM_NUMERATOR)
+        .ok_or(QuorumError::WeightOverflow)?;
+
+    if lhs < rhs {
+        return Ok(Resolution::NoQuorum);
+    }
+
+    match approve_weight.cmp(&reject_weight) {
+        // Strictly more Approve weight than Reject weight: Approved.
+        Ordering::Greater => Ok(Resolution::Approved),
+        // Equal (a genuine tie, or 0 == 0 when everyone abstained) or Reject
+        // weight leads outright: both resolve to Rejected. See the
+        // module-level "Ties" section for the fail-closed rationale.
+        Ordering::Equal | Ordering::Less => Ok(Resolution::Rejected),
+    }
+}

--- a/packages/contracts/contracts/sentinel-pool/src/test.rs
+++ b/packages/contracts/contracts/sentinel-pool/src/test.rs
@@ -1,0 +1,168 @@
+//! Exhaustive tests for [`resolve`], covering the quorum, tie, and
+//! abstention rules the module docs on `lib.rs` describe. Each test name
+//! states the scenario it pins down; taken together they are the
+//! executable half of "documented and exhaustively tested" from CT-015's
+//! acceptance criteria.
+
+use super::*;
+
+fn vote(verifier: u32, weight: u128, verdict: Verdict) -> Vote<u32> {
+    Vote {
+        verifier,
+        weight,
+        verdict,
+    }
+}
+
+// ── Quorum denominator ──────────────────────────────────────────────────
+
+#[test]
+fn no_votes_is_no_quorum() {
+    let votes: Vec<Vote<u32>> = vec![];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::NoQuorum));
+}
+
+#[test]
+fn participation_below_half_of_total_pool_weight_is_no_quorum() {
+    // 49/100 participating: one short of the 1/2 threshold.
+    let votes = vec![vote(1, 49, Verdict::Approve)];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::NoQuorum));
+}
+
+#[test]
+fn participation_at_exactly_half_of_total_pool_weight_reaches_quorum() {
+    // 50/100 participating: the threshold is inclusive.
+    let votes = vec![vote(1, 50, Verdict::Approve)];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::Approved));
+}
+
+#[test]
+fn quorum_is_measured_against_total_pool_weight_not_just_voters() {
+    // Two verifiers of a 1000-weight pool both vote Approve with only 100
+    // combined weight. If quorum were measured against participating
+    // weight alone (100), this would trivially "reach quorum" against
+    // itself. Measured against the real pool total (1000), it does not.
+    let votes = vec![
+        vote(1, 50, Verdict::Approve),
+        vote(2, 50, Verdict::Approve),
+    ];
+    assert_eq!(resolve(&votes, 1000), Ok(Resolution::NoQuorum));
+}
+
+#[test]
+fn full_pool_weight_participating_reaches_quorum() {
+    let votes = vec![vote(1, 100, Verdict::Approve)];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::Approved));
+}
+
+// ── Ties ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn equal_nonzero_approve_and_reject_weight_resolves_to_rejected() {
+    let votes = vec![
+        vote(1, 50, Verdict::Approve),
+        vote(2, 50, Verdict::Reject),
+    ];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::Rejected));
+}
+
+#[test]
+fn approve_strictly_greater_than_reject_resolves_to_approved() {
+    let votes = vec![
+        vote(1, 60, Verdict::Approve),
+        vote(2, 40, Verdict::Reject),
+    ];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::Approved));
+}
+
+#[test]
+fn reject_strictly_greater_than_approve_resolves_to_rejected() {
+    let votes = vec![
+        vote(1, 40, Verdict::Approve),
+        vote(2, 60, Verdict::Reject),
+    ];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::Rejected));
+}
+
+// ── Abstentions ──────────────────────────────────────────────────────────
+
+#[test]
+fn all_abstain_reaching_quorum_resolves_to_rejected() {
+    // Everyone shows up (reaching quorum) but nobody actually votes for or
+    // against: approve_weight == reject_weight == 0, so the tie rule
+    // applies.
+    let votes = vec![
+        vote(1, 60, Verdict::Abstain),
+        vote(2, 40, Verdict::Abstain),
+    ];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::Rejected));
+}
+
+#[test]
+fn abstain_counts_toward_quorum_but_not_the_tally() {
+    // 30 Approve + 10 Reject + 60 Abstain = 100/100 participating, which
+    // reaches quorum purely because Abstain weight is included. The tally
+    // is decided only by the 30 vs 10 split.
+    let votes = vec![
+        vote(1, 30, Verdict::Approve),
+        vote(2, 10, Verdict::Reject),
+        vote(3, 60, Verdict::Abstain),
+    ];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::Approved));
+}
+
+#[test]
+fn abstain_alone_can_be_insufficient_for_quorum() {
+    let votes = vec![vote(1, 40, Verdict::Abstain)];
+    assert_eq!(resolve(&votes, 100), Ok(Resolution::NoQuorum));
+}
+
+// ── Precondition errors ─────────────────────────────────────────────────
+
+#[test]
+fn zero_total_pool_weight_is_an_error() {
+    let votes = vec![vote(1, 10, Verdict::Approve)];
+    assert_eq!(resolve(&votes, 0), Err(QuorumError::ZeroTotalPoolWeight));
+}
+
+#[test]
+fn zero_weight_vote_is_an_error() {
+    let votes = vec![vote(1, 0, Verdict::Approve)];
+    assert_eq!(resolve(&votes, 100), Err(QuorumError::ZeroWeightVote));
+}
+
+#[test]
+fn duplicate_voter_is_an_error() {
+    let votes = vec![
+        vote(1, 10, Verdict::Approve),
+        vote(2, 10, Verdict::Reject),
+        vote(1, 10, Verdict::Approve),
+    ];
+    assert_eq!(resolve(&votes, 100), Err(QuorumError::DuplicateVoter));
+}
+
+#[test]
+fn votes_exceeding_total_pool_weight_is_an_error() {
+    // Combined vote weight (60 + 60 = 120) exceeds the stated pool total
+    // (100) — the caller must have passed a `total_pool_weight` that
+    // doesn't reflect every voter's registered stake.
+    let votes = vec![
+        vote(1, 60, Verdict::Approve),
+        vote(2, 60, Verdict::Reject),
+    ];
+    assert_eq!(
+        resolve(&votes, 100),
+        Err(QuorumError::VoteExceedsPoolWeight)
+    );
+}
+
+#[test]
+fn weight_overflow_in_quorum_check_is_an_error() {
+    // A single voter holding the entire (near-u128::MAX) pool weight
+    // doesn't exceed total_pool_weight, but doubling it for the quorum
+    // comparison (`participating_weight * QUORUM_DENOMINATOR`) overflows
+    // u128 and must be caught rather than silently wrapping.
+    let total = u128::MAX;
+    let votes = vec![vote(1, total, Verdict::Approve)];
+    assert_eq!(resolve(&votes, total), Err(QuorumError::WeightOverflow));
+}


### PR DESCRIPTION
Adds sentinel-pool crate with resolve(): the quorum/tie/abstention
rule CT-015 asks for. Quorum measured against total pool weight (not
just participants); ties (incl. all-abstain) resolve to Rejected;
abstain counts toward quorum, not the tally. 16 tests, verified
passing locally.

Closes #490