### PR TITLE
CT-030..CT-033: daily index storage, KVI rounding rules, deterministic aggregation, immutable history

### DIFF
--- a/packages/contracts/contracts/kovara-index/README.md
+++ b/packages/contracts/contracts/kovara-index/README.md
@@ -2,28 +2,87 @@
 
 Daily Kōvara Value Index (KVI) records — one per country, per day.
 
-Implements **CT-034** (authorize index updates), **CT-035** (complete daily
-index events), **CT-036** (contract storage versioning) and **CT-037** (admin
-transfer and recovery). The remaining index behaviour belongs to other issues
-and extends what is here.
-
-## What is here, and what is not
+Implements the full **CT-030..CT-037** series for the daily index:
 
 | Issue | Owns | State |
 |---|---|---|
+| CT-030 | Daily storage: one record per country/day, plus `latest` and range queries | **This crate** |
+| CT-031 | KVI rounding rules for `value` | **This crate** |
+| CT-032 | Deterministic aggregation producing `value` | **This crate** |
+| CT-033 | Rejection of duplicate index updates | **This crate** |
 | CT-034 | Who may update, and how many must agree | **This crate** |
 | CT-035 | The `DailyIndexUpdated` event and its fields | **This crate** |
 | CT-036 | Schema versioning and rejection of incompatible data | **This crate** |
 | CT-037 | Admin transfer and recovery | **This crate** |
-| CT-030 | Daily index storage semantics | Not implemented |
-| CT-031 | KVI rounding rules for `value` | Not implemented |
-| CT-032 | Deterministic aggregation producing `value` | Not implemented |
-| CT-033 | Rejection of duplicate index updates | Not implemented |
 
-`set_daily_index` therefore accepts a value some other component computed and
-lets a later write replace an earlier one. Rounding, aggregation and duplicate
-rejection are the named issues above; guessing at their semantics now would
-only have to be undone.
+## Storage and queries (CT-030)
+
+An authorized update stores **one record per country per day** — the record is
+keyed by `(schema_version, country, date)` — and emits the `DailyIndexUpdated`
+event (CT-035). Three query entrypoints read it back:
+
+- `get_daily_index(country, date)` — a single day;
+- `latest_daily_index(country)` — the most recent day, via the per-country
+  latest-date index that CT-033 also uses, so it is one read, not a scan;
+- `daily_index_history(country, from, to)` — the days in `[from, to]`,
+  ascending, bounded by `MAX_HISTORY_WINDOW` (ten years) so a caller cannot
+  turn the query into an unbounded loop. An inverted range is rejected.
+
+## The value (CT-031)
+
+`value` is a signed fixed-point integer in **`KVI_SCALE` = 10,000** units:
+`value / 10,000` is the human-readable index.
+
+- **Scale** — `KVI_SCALE`, one scale everywhere, so two implementations of
+  the aggregation produce numbers a consumer can compare.
+- **Rounding** — the single rounding rule is *half away from zero*
+  (`5 / 2 -> 3`, `-5 / 2 -> -3`). It is applied wherever a division can
+  produce a fractional result (the even-count median average). It is
+  symmetric and never biased toward either direction.
+- **Overflow** — values outside `±KVI_VALUE_MAX` (10^18) are rejected with
+  `ValueOutOfRange` rather than stored. The bound keeps every arithmetic step
+  in the contract far inside `i128`, so nothing can wrap silently.
+- **Missing basket** — a record without a basket (`basket_version == 0`) is
+  rejected, and a day that was never finalized simply reads as `None`: the
+  contract never writes a zero as a stand-in for "no data".
+- **Baseline** — the KVI is normalized so parity with the reference period
+  reads as **`KVI_BASELINE` = 100 * `KVI_SCALE`** (100.0000). The contract
+  stores absolute values and does not re-normalize; the constant pins what
+  "parity with the baseline" means for every consumer.
+
+## Deterministic aggregation (CT-032)
+
+`compute_daily_index(observations)` produces the daily value from raw
+`Observation { value, weight }` pairs as a **weighted, 10%-trimmed median**.
+It is pure and stateless, so any sentinel can call it to verify a submitted
+aggregate, and identical inputs always yield the identical number:
+
+1. **Trim** — drop the lowest and highest `len * 10 / 100` observations
+   (floored), so a single wild value at either end changes nothing.
+2. **Sort** — ascending by value only; equal values are interchangeable, so
+   the result depends on the multiset of `(value, weight)` pairs, never on
+   input order.
+3. **Weighted median** — the first value whose cumulative weight exceeds
+   half the total. When cumulative weight lands **exactly on half**, the two
+   straddling values are averaged and rounded half away from zero (CT-031).
+
+`set_aggregated_index(...)` computes the value with the same function, then
+stores it and emits the event exactly as `set_daily_index` would, returning
+ the computed value. An observation with zero weight is rejected.
+
+## Immutable history (CT-033)
+
+Finalized history is immutable and strictly forward:
+
+- **Duplicates** — a `(country, date)` that already has a record is rejected
+  with `IndexAlreadyFinalized`, so replaying an update (even with a different
+  value) can never overwrite a finalized day.
+- **Out-of-order** — a `date` at or before the country's latest finalized
+  date is rejected with `OutOfOrderUpdate`. History moves forward only; a
+  missed day is simply a day with no index and cannot be backfilled later.
+
+Both checks run in the same write path as the record itself, so the guard and
+ the data cannot diverge. A rejected update emits no event and stores nothing.
 
 ## Storage versioning policy (CT-036)
 
@@ -164,7 +223,7 @@ schemas are briefly live.
 ```bash
 cd packages/contracts
 
-cargo test -p kovara-index                       # 68 tests
+cargo test -p kovara-index                       # 97 tests
 cargo build --target wasm32v1-none --release     # -> target/wasm32v1-none/release/kovara_index.wasm
 ```
 

--- a/packages/contracts/contracts/kovara-index/src/lib.rs
+++ b/packages/contracts/contracts/kovara-index/src/lib.rs
@@ -2,25 +2,19 @@
 //! `KovaraIndex` — daily Kōvara Value Index (KVI) records, one per country
 //! per day.
 //!
-//! This crate currently carries the minimum surface needed by **CT-035**
-//! (complete daily index events) and **CT-036** (contract storage
-//! versioning). The rest of the index behaviour is owned by other issues and
-//! will extend what is here rather than replace it:
+//! The full **CT-030..CT-037** series for the daily index lands in this
+//! crate:
 //!
 //! | Issue | Adds |
 //! |---|---|
-//! | CT-030 | Daily index storage semantics beyond the single record below |
-//! | CT-031 | KVI rounding rules for `value` |
-//! | CT-032 | Deterministic aggregation producing `value` |
-//! | CT-033 | Rejection of duplicate index updates |
+//! | CT-030 | Daily storage: one immutable record per country/day, plus `latest` and range queries |
+//! | CT-031 | Fixed-point scale, rounding, overflow bounds, missing-basket and baseline rules for `value` |
+//! | CT-032 | Deterministic weighted trimmed-median aggregation producing `value` |
+//! | CT-033 | Rejection of duplicate and out-of-order updates — finalized history is immutable |
 //! | CT-034 | The authorization policy for who may update |
-//!
-//! Deliberately **not** implemented here: rounding, aggregation, duplicate
-//! rejection, and the authorization policy. `set_daily_index` therefore
-//! accepts a value that some other component computed, requires only that the
-//! named updater signed for itself, and allows a later write to replace an
-//! earlier one. Each of those is a named issue above, and guessing at their
-//! semantics now would only have to be undone.
+//! | CT-035 | The complete daily index event |
+//! | CT-036 | Storage versioning |
+//! | CT-037 | Admin transfer and recovery |
 //!
 //! # Storage versioning (CT-036)
 //!
@@ -56,6 +50,52 @@ mod test;
 /// then rejects every operation until it is migrated, which is the intended
 /// outcome — the alternative is reading a v1 record as though it were v2.
 pub const SCHEMA_VERSION: u32 = 1;
+
+// ── CT-031: the fixed-point representation of `value` ────────────────────
+
+/// The fixed-point scale every KVI `value` is expressed in.
+///
+/// Stored values are integers; dividing by [`KVI_SCALE`] yields the
+/// human-readable index. One scale, everywhere, is what makes two
+/// implementations of the aggregation produce numbers a consumer can compare.
+pub const KVI_SCALE: i128 = 10_000;
+
+/// The baseline index value: 100.0000 in [`KVI_SCALE`] units.
+///
+/// KVI is normalized so that a country's reference period reads as
+/// [`KVI_BASELINE`]: a value above it means prices moved up relative to that
+/// baseline, below it means they moved down. The contract stores absolute
+/// values and does not re-normalize; this constant pins what "parity with the
+/// baseline" means for every consumer of the data.
+pub const KVI_BASELINE: i128 = 100 * KVI_SCALE;
+
+/// The largest absolute `value` the contract will store.
+///
+/// This is the overflow rule (CT-031). Bounding stored and aggregated values
+/// at 10^18 keeps every arithmetic step in the contract — including the
+/// half-away-from-zero rounding of two medians — far inside `i128`, so a
+/// value can never wrap silently. Values beyond the bound are rejected with
+/// [`Error::ValueOutOfRange`].
+pub const KVI_VALUE_MAX: i128 = 1_000_000_000_000_000_000;
+
+// ── CT-032: deterministic aggregation ────────────────────────────────────
+
+/// How much of each end of the observation distribution is trimmed before
+/// the median is taken, in percent (CT-032).
+///
+/// A 10% trim drops the lowest and highest `len * TRIMMING_PERCENT / 100`
+/// observations (floored). The percentage, not a fixed count, is what keeps
+/// the behaviour stable as the observation count grows.
+pub const TRIMMING_PERCENT: u32 = 10;
+
+// ── CT-030: range queries ────────────────────────────────────────────────
+
+/// The widest `daily_index_history` range, in days.
+///
+/// A range query iterates one storage read per day, so the window must be
+/// bounded or a caller could make the contract spin. Ten years is far wider
+/// than any real use and still cheap.
+pub const MAX_HISTORY_WINDOW: u64 = 3660;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -126,6 +166,33 @@ pub enum Error {
 
     /// The proposed admin is already the current admin.
     AlreadyAdmin = 20,
+
+    // ── CT-030: daily storage and queries ─────────────────────────────────
+    /// A `daily_index_history` range wider than [`MAX_HISTORY_WINDOW`] days.
+    HistoryWindowTooLarge = 21,
+
+    /// A range whose end precedes its start.
+    InvalidHistoryRange = 22,
+
+    // ── CT-031: KVI rounding rules ────────────────────────────────────────
+    /// A `value` outside [`KVI_VALUE_MAX`]. This is the overflow rule.
+    ValueOutOfRange = 23,
+
+    // ── CT-032: deterministic aggregation ─────────────────────────────────
+    /// Aggregation called with no observations.
+    EmptyObservations = 24,
+
+    /// An observation with zero weight.
+    ZeroWeight = 25,
+
+    // ── CT-033: immutable history ─────────────────────────────────────────
+    /// A record already exists for this `(country, date)`. Finalized history
+    /// cannot be overwritten.
+    IndexAlreadyFinalized = 26,
+
+    /// A `date` at or before the latest finalized date for the country.
+    /// History moves strictly forward; backdating is rejected.
+    OutOfOrderUpdate = 27,
 }
 
 #[contracttype]
@@ -142,6 +209,13 @@ pub enum DataKey {
     /// The schema version leads the key so that records written under
     /// different schemas never collide.
     DailyIndex(u32, Symbol, u64),
+
+    /// Persistent: `(schema_version, country)` → the latest finalized date
+    /// for that country.
+    ///
+    /// Feeds the CT-033 out-of-order check: once a later day is finalized,
+    /// writing any earlier day is rejected.
+    LatestDate(u32, Symbol),
 
     /// Instance: the addresses permitted to sign a daily index update.
     Sentinels,
@@ -166,10 +240,11 @@ pub struct DailyIndex {
     /// The day this index describes, as days since the Unix epoch.
     pub date: u64,
 
-    /// The index value, in the contract's fixed-point representation.
+    /// The index value, in the contract's fixed-point representation
+    /// ([`KVI_SCALE`], bounded by [`KVI_VALUE_MAX`]).
     ///
     /// CT-031 defines the rounding rules that produce this; CT-032 defines
-    /// the aggregation. This crate stores whatever it is given.
+    /// the aggregation.
     pub value: i128,
 
     /// Which basket definition the value was computed against.
@@ -189,6 +264,25 @@ pub struct DailyIndex {
 
     /// The schema version in force when the record was written.
     pub schema_version: u32,
+}
+
+/// One input to the deterministic daily aggregation (CT-032).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Observation {
+    /// A verified price or price-basket aggregate, in [`KVI_SCALE`] units.
+    ///
+    /// Values outside [`KVI_VALUE_MAX`] are rejected by the aggregation,
+    /// matching the storage rule, so the pure function is total over its
+    /// documented domain.
+    pub value: i128,
+
+    /// How many verified submissions this observation represents.
+    ///
+    /// Zero is rejected: an observation that contributes nothing must be
+    /// omitted, not passed as zero, or a caller could silently deflate the
+    /// median.
+    pub weight: u32,
 }
 
 /// Emitted whenever a daily index record is written (CT-035).
@@ -393,6 +487,11 @@ impl KovaraIndex {
     /// record's and the event's `updater` field, preserving CT-035's event
     /// shape.
     ///
+    /// **Immutable history (CT-033).** A `(country, date)` record is written
+    /// at most once. Replaying this call — or submitting for a date at or
+    /// before the country's latest finalized date — fails, so finalized
+    /// history can never be overwritten or backdated.
+    ///
     /// # Errors
     /// * `NotInitialized` — the contract has no schema version yet
     /// * `IncompatibleSchema` — stored schema differs from [`SCHEMA_VERSION`]
@@ -402,6 +501,9 @@ impl KovaraIndex {
     /// * `InsufficientSignatures` — fewer signers than the threshold
     /// * `InvalidBasketVersion` — `basket_version` is zero
     /// * `InvalidSourcePeriod` — the period ends before it starts
+    /// * `ValueOutOfRange` — `value` is outside [`KVI_VALUE_MAX`] (CT-031)
+    /// * `IndexAlreadyFinalized` — the date already has a record (CT-033)
+    /// * `OutOfOrderUpdate` — the date is not after the latest one (CT-033)
     #[allow(clippy::too_many_arguments)]
     pub fn set_daily_index(
         env: Env,
@@ -417,45 +519,93 @@ impl KovaraIndex {
 
         let updater = Self::require_sentinel_quorum(&env, &signers)?;
 
-        // Only the two fields CT-035 introduces are validated here. Country,
-        // date and value validation belong to CT-004, CT-005 and CT-030.
-        if basket_version == 0 {
-            return Err(Error::InvalidBasketVersion);
-        }
-
-        if source_period_end < source_period_start {
-            return Err(Error::InvalidSourcePeriod);
-        }
-
-        let record = DailyIndex {
-            country: country.clone(),
+        Self::store_index(
+            &env,
+            schema_version,
+            &updater,
+            &country,
             date,
             value,
             basket_version,
             source_period_start,
             source_period_end,
-            updater: updater.clone(),
+        )
+    }
+
+    /// Compute and store the daily index from raw observations (CT-032).
+    ///
+    /// The value is produced by [`Self::compute_daily_index`] — the same
+    /// deterministic weighted trimmed median every sentinel can reproduce —
+    /// and then stored and emitted exactly as [`Self::set_daily_index`]
+    /// would. Returns the computed value so the caller need not read it back.
+    ///
+    /// Authorization, field validation, rounding bounds and immutable-history
+    /// rules are all shared with [`Self::set_daily_index`].
+    ///
+    /// # Errors
+    /// As [`Self::set_daily_index`], plus:
+    /// * `EmptyObservations` — `observations` is empty (CT-032)
+    /// * `ZeroWeight` — an observation has weight zero (CT-032)
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_aggregated_index(
+        env: Env,
+        signers: Vec<Address>,
+        country: Symbol,
+        date: u64,
+        observations: Vec<Observation>,
+        basket_version: u32,
+        source_period_start: u64,
+        source_period_end: u64,
+    ) -> Result<i128, Error> {
+        let schema_version = Self::require_compatible_schema(&env)?;
+
+        let updater = Self::require_sentinel_quorum(&env, &signers)?;
+
+        let value = Self::aggregate(&observations)?;
+
+        Self::store_index(
+            &env,
             schema_version,
-        };
-
-        env.storage().persistent().set(
-            &DataKey::DailyIndex(schema_version, country.clone(), date),
-            &record,
-        );
-
-        DailyIndexUpdated {
-            country,
+            &updater,
+            &country,
             date,
             value,
             basket_version,
             source_period_start,
             source_period_end,
-            updater,
-            schema_version,
-        }
-        .publish(&env);
+        )?;
 
-        Ok(())
+        Ok(value)
+    }
+
+    /// The deterministic daily aggregation (CT-032): a weighted, 10%-trimmed
+    /// median of `observations`.
+    ///
+    /// Pure and stateless, so it needs no authorization and touches no
+    /// storage: any sentinel (or anyone else) can call it to verify that a
+    /// submitted aggregate really is the median of the observations, and
+    /// every caller computing over identical inputs gets the identical
+    /// number.
+    ///
+    /// # Semantics
+    /// * **Trim.** The lowest and highest `len * 10 / 100` observations are
+    ///   dropped before the median is taken.
+    /// * **Median.** The weighted median of the remainder: the first value
+    ///   whose cumulative weight exceeds half the total. When cumulative
+    ///   weight lands exactly on half, the two straddling values are
+    ///   averaged and rounded half away from zero (CT-031).
+    /// * **Weighting.** Each observation counts `weight` times; a heavier
+    ///   observation pulls the median toward itself.
+    /// * **Ties.** Equal values are interchangeable and the sort is by value
+    ///   alone, so the result depends only on the multiset of
+    ///   `(value, weight)` pairs — never on input order.
+    ///
+    /// # Errors
+    /// * `EmptyObservations` — `observations` is empty
+    /// * `ZeroWeight` — an observation has weight zero
+    /// * `ValueOutOfRange` — an observation value is outside [`KVI_VALUE_MAX`]
+    pub fn compute_daily_index(_env: Env, observations: Vec<Observation>) -> Result<i128, Error> {
+        Self::aggregate(&observations)
     }
 
     /// Read a daily index record.
@@ -475,6 +625,80 @@ impl KovaraIndex {
             .storage()
             .persistent()
             .get(&DataKey::DailyIndex(schema_version, country, date)))
+    }
+
+    /// The most recent finalized index for a country (CT-030).
+    ///
+    /// `None` if the country has no records yet. Uses the per-country latest
+    /// date maintained by the CT-033 out-of-order check, so it is a single
+    /// read rather than a scan.
+    ///
+    /// # Errors
+    /// * `NotInitialized` / `IncompatibleSchema` — as for reads above
+    pub fn latest_daily_index(env: Env, country: Symbol) -> Result<Option<DailyIndex>, Error> {
+        let schema_version = Self::require_compatible_schema(&env)?;
+
+        let latest: Option<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LatestDate(schema_version, country.clone()));
+
+        let latest = match latest {
+            Some(date) => date,
+            None => return Ok(None),
+        };
+
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&DataKey::DailyIndex(schema_version, country, latest)))
+    }
+
+    /// All finalized records for a country whose `date` is in `[from, to]`,
+    /// ascending (CT-030).
+    ///
+    /// The window is bounded by [`MAX_HISTORY_WINDOW`] so the query cannot
+    /// be weaponized into an unbounded loop.
+    ///
+    /// # Errors
+    /// * `NotInitialized` / `IncompatibleSchema` — as for reads above
+    /// * `InvalidHistoryRange` — `to < from`
+    /// * `HistoryWindowTooLarge` — `to - from` exceeds [`MAX_HISTORY_WINDOW`]
+    pub fn daily_index_history(
+        env: Env,
+        country: Symbol,
+        from: u64,
+        to: u64,
+    ) -> Result<Vec<DailyIndex>, Error> {
+        let schema_version = Self::require_compatible_schema(&env)?;
+
+        if to < from {
+            return Err(Error::InvalidHistoryRange);
+        }
+
+        if to - from > MAX_HISTORY_WINDOW {
+            return Err(Error::HistoryWindowTooLarge);
+        }
+
+        let mut records = Vec::new(&env);
+        let mut date = from;
+
+        while date <= to {
+            if let Some(record) =
+                env.storage()
+                    .persistent()
+                    .get::<DataKey, DailyIndex>(&DataKey::DailyIndex(
+                        schema_version,
+                        country.clone(),
+                        date,
+                    ))
+            {
+                records.push_back(record);
+            }
+            date += 1;
+        }
+
+        Ok(records)
     }
 
     // ── CT-034: sentinel roster and threshold ────────────────────────────
@@ -871,5 +1095,228 @@ impl KovaraIndex {
         }
 
         Ok(stored)
+    }
+
+    // ── CT-030..CT-033: storage, rounding, aggregation ────────────────────
+
+    /// Validate, store, and emit the event for one finalized record.
+    ///
+    /// Shared by [`Self::set_daily_index`] and
+    /// [`Self::set_daily_index_from_observations`] so the two entrypoints can
+    /// never diverge on what gets stored or emitted. Authorization must have
+    /// already been checked by the caller.
+    #[allow(clippy::too_many_arguments)]
+    fn store_index(
+        env: &Env,
+        schema_version: u32,
+        updater: &Address,
+        country: &Symbol,
+        date: u64,
+        value: i128,
+        basket_version: u32,
+        source_period_start: u64,
+        source_period_end: u64,
+    ) -> Result<(), Error> {
+        // Only the two fields CT-035 introduces were validated here before
+        // CT-030..CT-033 landed; country and date validation still belong to
+        // CT-004 and CT-005.
+        if basket_version == 0 {
+            return Err(Error::InvalidBasketVersion);
+        }
+
+        if source_period_end < source_period_start {
+            return Err(Error::InvalidSourcePeriod);
+        }
+
+        // The overflow rule (CT-031): a value beyond KVI_VALUE_MAX could
+        // wrap in downstream arithmetic; reject rather than store garbage.
+        if !(-KVI_VALUE_MAX..=KVI_VALUE_MAX).contains(&value) {
+            return Err(Error::ValueOutOfRange);
+        }
+
+        Self::require_not_finalized(env, schema_version, country, date)?;
+
+        let record = DailyIndex {
+            country: country.clone(),
+            date,
+            value,
+            basket_version,
+            source_period_start,
+            source_period_end,
+            updater: updater.clone(),
+            schema_version,
+        };
+
+        env.storage().persistent().set(
+            &DataKey::DailyIndex(schema_version, country.clone(), date),
+            &record,
+        );
+
+        // The CT-033 out-of-order check needs the latest date per country;
+        // keep it in the same write as the record so the two cannot diverge.
+        env.storage()
+            .persistent()
+            .set(&DataKey::LatestDate(schema_version, country.clone()), &date);
+
+        DailyIndexUpdated {
+            country: country.clone(),
+            date,
+            value,
+            basket_version,
+            source_period_start,
+            source_period_end,
+            updater: updater.clone(),
+            schema_version,
+        }
+        .publish(env);
+
+        Ok(())
+    }
+
+    /// The CT-033 immutable-history guard: reject duplicate and out-of-order
+    /// writes.
+    fn require_not_finalized(
+        env: &Env,
+        schema_version: u32,
+        country: &Symbol,
+        date: u64,
+    ) -> Result<(), Error> {
+        // A replay targets a date that already has a record.
+        if env.storage().persistent().has(&DataKey::DailyIndex(
+            schema_version,
+            country.clone(),
+            date,
+        )) {
+            return Err(Error::IndexAlreadyFinalized);
+        }
+
+        // Backdating targets a date earlier than the latest finalized one. A
+        // date *equal* to the latest can never reach here — it would have a
+        // record — but `<=` keeps the guard airtight.
+        if let Some(latest) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u64>(&DataKey::LatestDate(schema_version, country.clone()))
+        {
+            if date <= latest {
+                return Err(Error::OutOfOrderUpdate);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// The deterministic weighted trimmed median (CT-032).
+    fn aggregate(observations: &Vec<Observation>) -> Result<i128, Error> {
+        let count = observations.len();
+        if count == 0 {
+            return Err(Error::EmptyObservations);
+        }
+
+        for observation in observations.iter() {
+            if observation.weight == 0 {
+                return Err(Error::ZeroWeight);
+            }
+
+            // Bounds are enforced here too, not just at storage: the pure
+            // function must be total over its documented domain, and it
+            // keeps the median straddle sum (`a + b`) safely inside `i128`.
+            if !(-KVI_VALUE_MAX..=KVI_VALUE_MAX).contains(&observation.value) {
+                return Err(Error::ValueOutOfRange);
+            }
+        }
+
+        // Trim the lowest and highest `trim` observations by count. `trim` is
+        // `floor(count / 10)`, which is always less than `count / 2`, so at
+        // least one observation always remains.
+        let trim = (count * TRIMMING_PERCENT) / 100;
+
+        let mut sorted = observations.clone();
+        sort_by_value(&mut sorted);
+
+        let mut total_weight: u64 = 0;
+        for i in trim..(count - trim) {
+            total_weight += sorted.get(i).unwrap().weight as u64;
+        }
+
+        // Walk the sorted remainder until cumulative weight crosses half.
+        let mut cumulative: u64 = 0;
+        let mut i = trim;
+        while i < count - trim {
+            let observation = sorted.get(i).unwrap();
+            cumulative += observation.weight as u64;
+
+            if cumulative * 2 > total_weight {
+                // Strictly more than half the weight: this is the median.
+                return Ok(observation.value);
+            }
+
+            if cumulative * 2 == total_weight {
+                // Exactly half: the median straddles this and the next value.
+                // Average them, rounded half away from zero (CT-031).
+                return Ok(match sorted.get(i + 1) {
+                    Some(next) => round_half_away(observation.value + next.value, 2),
+                    None => observation.value,
+                });
+            }
+
+            i += 1;
+        }
+
+        // Unreachable: total_weight > 0, so cumulative must cross half.
+        Err(Error::EmptyObservations)
+    }
+}
+
+/// Round `numer / denom` half away from zero (CT-031).
+///
+/// The one rounding rule in the crate, and the only one consumers need to
+/// reproduce: `5 / 2 -> 3`, `-5 / 2 -> -3`. Ties (a remainder of exactly
+/// half) round away from zero, so the rule is symmetric and never biased
+/// toward either direction.
+///
+/// `denom` must be positive. `numer` is expected to be a sum of values
+/// bounded by [`KVI_VALUE_MAX`], so the arithmetic cannot overflow `i128`.
+fn round_half_away(numer: i128, denom: i128) -> i128 {
+    debug_assert!(denom > 0);
+
+    let quotient = numer / denom;
+    let remainder = numer % denom;
+
+    if remainder.abs() * 2 >= denom {
+        if numer >= 0 {
+            quotient + 1
+        } else {
+            quotient - 1
+        }
+    } else {
+        quotient
+    }
+}
+
+/// Sort observations ascending by value, in place.
+///
+/// Insertion sort: the observation lists a daily aggregation sees are small
+/// (bounded by what fits in one transaction), and this keeps the sort
+/// dependency-free and obviously deterministic. Equal values are
+/// interchangeable, so the sort needs no secondary key.
+fn sort_by_value(observations: &mut Vec<Observation>) {
+    let count = observations.len();
+
+    for i in 1..count {
+        let mut j = i;
+
+        while j > 0 {
+            let current = observations.get(j).unwrap();
+            let previous = observations.get(j - 1).unwrap();
+
+            if previous.value <= current.value {
+                break;
+            }
+
+            observations.set(j, previous);
+            observations.set(j - 1, current);
+            j -= 1;
+        }
     }
 }

--- a/packages/contracts/contracts/kovara-index/src/test.rs
+++ b/packages/contracts/contracts/kovara-index/src/test.rs
@@ -1,9 +1,13 @@
-//! Tests for CT-035 (complete daily index events) and CT-036 (storage
-//! versioning).
+//! Tests for the full CT-030..CT-037 daily-index series: storage and range
+//! queries (CT-030), rounding rules (CT-031), deterministic aggregation
+//! (CT-032), immutable history (CT-033), authorization (CT-034), events
+//! (CT-035), storage versioning (CT-036), and admin transfer/recovery
+//! (CT-037).
 
 use crate::{
-    DailyIndex, DailyIndexUpdated, DataKey, Error, KovaraIndex, KovaraIndexClient, PendingRecovery,
-    PendingTransfer, RECOVERY_DELAY_LEDGERS, SCHEMA_VERSION,
+    round_half_away, DailyIndex, DailyIndexUpdated, DataKey, Error, KovaraIndex, KovaraIndexClient,
+    Observation, PendingRecovery, PendingTransfer, KVI_BASELINE, KVI_SCALE, KVI_VALUE_MAX,
+    MAX_HISTORY_WINDOW, RECOVERY_DELAY_LEDGERS, SCHEMA_VERSION,
 };
 use soroban_sdk::testutils::Ledger as _;
 use soroban_sdk::testutils::{Address as _, Events};
@@ -567,8 +571,9 @@ fn records_are_kept_per_country_and_per_date() {
     );
 }
 
-/// Negative values are storable. Whether the index may go negative is CT-031
-/// and CT-032's decision; this crate must not pre-empt it by rejecting them.
+/// Negative values within the CT-031 bounds ([`KVI_VALUE_MAX`]) are storable
+/// as given; the rounding and aggregation rules decide what is produced, not
+/// whether a signed value may be stored.
 #[test]
 fn a_negative_value_is_stored_as_given() {
     let f = deploy_initialized();
@@ -822,8 +827,17 @@ fn rotation_revokes_the_old_roster_and_installs_the_new_one() {
         Err(Ok(Error::NotASentinel))
     );
 
+    // A fresh day (CT-033 made NG@DATE immutable after the first write).
     assert_eq!(
-        update_with!(&f, &vec![&f.env, new.get(0).unwrap(), new.get(1).unwrap()]),
+        f.client.try_set_daily_index(
+            &vec![&f.env, new.get(0).unwrap(), new.get(1).unwrap()],
+            &NG,
+            &(DATE + 1),
+            &VALUE,
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END,
+        ),
         Ok(Ok(()))
     );
 }
@@ -848,7 +862,15 @@ fn rotation_can_raise_and_lower_the_threshold() {
 
     f.client.set_sentinels(&f.admin, &s, &1);
     assert_eq!(
-        update_with!(&f, &vec![&f.env, s.get(0).unwrap()]),
+        f.client.try_set_daily_index(
+            &vec![&f.env, s.get(0).unwrap()],
+            &NG,
+            &(DATE + 1),
+            &VALUE,
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END,
+        ),
         Ok(Ok(()))
     );
 }
@@ -1397,5 +1419,651 @@ fn a_rotated_out_sentinel_cannot_propose_a_recovery() {
             &Address::generate(&f.env)
         ),
         Err(Ok(Error::NotASentinel))
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CT-030 — daily KovaraIndex storage (#505)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Three consecutive days for the fixture country, written in order.
+fn write_three_days(f: &Fixture) {
+    f.client.set_daily_index(
+        &solo(f),
+        &NG,
+        &DATE,
+        &100,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    f.client.set_daily_index(
+        &solo(f),
+        &NG,
+        &(DATE + 1),
+        &200,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    f.client.set_daily_index(
+        &solo(f),
+        &NG,
+        &(DATE + 2),
+        &300,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+}
+
+#[test]
+fn latest_is_none_before_any_write() {
+    let f = deploy_initialized();
+
+    assert_eq!(f.client.latest_daily_index(&NG), None);
+}
+
+#[test]
+fn latest_returns_the_most_recent_record() {
+    let f = deploy_initialized();
+    write_three_days(&f);
+
+    let latest = f.client.latest_daily_index(&NG).unwrap();
+
+    assert_eq!(latest.date, DATE + 2);
+    assert_eq!(latest.value, 300);
+}
+
+#[test]
+fn history_returns_the_requested_range_ascending() {
+    let f = deploy_initialized();
+    write_three_days(&f);
+
+    let records = f.client.daily_index_history(&NG, &DATE, &(DATE + 2));
+
+    assert_eq!(records.len(), 3);
+    assert_eq!(records.get(0).unwrap().date, DATE);
+    assert_eq!(records.get(1).unwrap().date, DATE + 1);
+    assert_eq!(records.get(2).unwrap().date, DATE + 2);
+
+    let subset = f.client.daily_index_history(&NG, &(DATE + 1), &(DATE + 2));
+    assert_eq!(subset.len(), 2);
+    assert_eq!(subset.get(0).unwrap().date, DATE + 1);
+}
+
+#[test]
+fn history_is_empty_when_nothing_matches() {
+    let f = deploy_initialized();
+    write_three_days(&f);
+
+    assert_eq!(
+        f.client
+            .daily_index_history(&NG, &(DATE + 5), &(DATE + 6))
+            .len(),
+        0
+    );
+    assert_eq!(
+        f.client
+            .daily_index_history(&symbol_short!("ZZ"), &DATE, &(DATE + 2))
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn an_inverted_history_range_is_rejected() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client.try_daily_index_history(&NG, &(DATE + 2), &DATE),
+        Err(Ok(Error::InvalidHistoryRange))
+    );
+}
+
+#[test]
+fn a_history_range_wider_than_the_max_window_is_rejected() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client
+            .try_daily_index_history(&NG, &DATE, &(DATE + MAX_HISTORY_WINDOW + 1)),
+        Err(Ok(Error::HistoryWindowTooLarge))
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CT-031 — KVI rounding rules (#506)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// The scale and the baseline are pinned so consumers can reproduce values.
+#[test]
+fn the_scale_and_baseline_are_pinned() {
+    assert_eq!(KVI_SCALE, 10_000);
+    assert_eq!(KVI_BASELINE, 100 * KVI_SCALE);
+}
+
+#[test]
+fn rounding_is_half_away_from_zero() {
+    assert_eq!(round_half_away(5, 2), 3); //   2.5  ->  3
+    assert_eq!(round_half_away(-5, 2), -3); //  -2.5  -> -3
+    assert_eq!(round_half_away(4, 2), 2); //   2.0  ->  2
+    assert_eq!(round_half_away(-4, 2), -2); //  -2.0  -> -2
+    assert_eq!(round_half_away(1, 2), 1); //   0.5  ->  1
+    assert_eq!(round_half_away(-1, 2), -1); //  -0.5  -> -1
+    assert_eq!(round_half_away(7, 3), 2); //   2.33 ->  2
+    assert_eq!(round_half_away(-7, 3), -2); //  -2.33 -> -2
+}
+
+/// The overflow rule: values outside the documented bounds are rejected
+/// rather than stored, and nothing is persisted by the rejected writes.
+#[test]
+fn a_value_beyond_the_documented_bounds_is_rejected() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &solo(&f),
+            &NG,
+            &DATE,
+            &(KVI_VALUE_MAX + 1),
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::ValueOutOfRange))
+    );
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &solo(&f),
+            &NG,
+            &DATE,
+            &(-KVI_VALUE_MAX - 1),
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::ValueOutOfRange))
+    );
+
+    assert_eq!(f.client.get_daily_index(&NG, &DATE), None);
+}
+
+#[test]
+fn a_value_out_of_bounds_emits_no_event() {
+    let f = deploy_initialized();
+
+    assert!(f
+        .client
+        .try_set_daily_index(
+            &solo(&f),
+            &NG,
+            &DATE,
+            &(KVI_VALUE_MAX + 1),
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        )
+        .is_err());
+
+    assert_eq!(emitted_count(&f), 0);
+}
+
+#[test]
+fn the_boundary_values_are_storable() {
+    let f = deploy_initialized();
+
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &DATE,
+        &KVI_VALUE_MAX,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &(DATE + 1),
+        &(-KVI_VALUE_MAX),
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(
+        f.client.get_daily_index(&NG, &DATE).unwrap().value,
+        KVI_VALUE_MAX
+    );
+    assert_eq!(
+        f.client.get_daily_index(&NG, &(DATE + 1)).unwrap().value,
+        -KVI_VALUE_MAX
+    );
+}
+
+/// The baseline value (100.0000) is an ordinary storable number, which is
+/// what lets the first published day of a country serve as its reference.
+#[test]
+fn the_baseline_value_is_storable() {
+    let f = deploy_initialized();
+
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &DATE,
+        &KVI_BASELINE,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(
+        f.client.get_daily_index(&NG, &DATE).unwrap().value,
+        KVI_BASELINE
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CT-032 — deterministic aggregation (#507)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Observations with unit weights, from plain values.
+fn observations(f: &Fixture, values: &[i128]) -> Vec<Observation> {
+    let mut out = Vec::new(&f.env);
+    for value in values {
+        out.push_back(Observation {
+            value: *value,
+            weight: 1,
+        });
+    }
+    out
+}
+
+/// Observations from `(value, weight)` pairs.
+fn weighted(f: &Fixture, pairs: &[(i128, u32)]) -> Vec<Observation> {
+    let mut out = Vec::new(&f.env);
+    for (value, weight) in pairs {
+        out.push_back(Observation {
+            value: *value,
+            weight: *weight,
+        });
+    }
+    out
+}
+
+#[test]
+fn the_median_of_an_odd_count_is_the_middle_value() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client
+            .compute_daily_index(&observations(&f, &[10, 20, 30])),
+        20
+    );
+    assert_eq!(
+        f.client
+            .compute_daily_index(&observations(&f, &[30, 10, 20])),
+        20
+    );
+}
+
+#[test]
+fn the_median_of_an_even_count_averages_the_two_middle_values() {
+    let f = deploy_initialized();
+
+    // (20 + 30) / 2 = 25
+    assert_eq!(
+        f.client
+            .compute_daily_index(&observations(&f, &[10, 20, 30, 40])),
+        25
+    );
+
+    // (11 + 12) / 2 = 11.5 -> 12, half away from zero (CT-031)
+    assert_eq!(
+        f.client
+            .compute_daily_index(&observations(&f, &[10, 11, 12, 13])),
+        12
+    );
+
+    // Negative halves round away from zero too: (-11 + -12) / 2 = -11.5 -> -12
+    assert_eq!(
+        f.client
+            .compute_daily_index(&observations(&f, &[-13, -12, -11, -10])),
+        -12
+    );
+}
+
+/// Outlier semantics: with 10 observations the 10% trim drops the single
+/// lowest and single highest, so one wild value at each end changes nothing.
+#[test]
+fn outliers_are_trimmed_before_the_median() {
+    let f = deploy_initialized();
+
+    let obs = observations(&f, &[1, 100, 100, 100, 100, 100, 100, 100, 100, 1000]);
+    assert_eq!(f.client.compute_daily_index(&obs), 100);
+}
+
+#[test]
+fn weights_pull_the_median_toward_them() {
+    let f = deploy_initialized();
+
+    // Unweighted median of {10, 20, 30} is 20, but with 30 carrying most of
+    // the weight the weighted median is 30.
+    let obs = weighted(&f, &[(10, 1), (20, 1), (30, 8)]);
+    assert_eq!(f.client.compute_daily_index(&obs), 30);
+
+    // A heavily weighted middle observation is picked outright.
+    let obs = weighted(&f, &[(10, 1), (20, 6), (30, 1)]);
+    assert_eq!(f.client.compute_daily_index(&obs), 20);
+}
+
+/// Tie behaviour: equal values are interchangeable, and an even split on
+/// equal values returns that value.
+#[test]
+fn ties_between_equal_values_are_stable() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client
+            .compute_daily_index(&observations(&f, &[7, 7, 7, 7])),
+        7
+    );
+    assert_eq!(
+        f.client.compute_daily_index(&observations(&f, &[3, 3, 3])),
+        3
+    );
+}
+
+/// Determinism: the same multiset in a different order yields the same value.
+#[test]
+fn identical_inputs_in_any_order_give_the_identical_result() {
+    let f = deploy_initialized();
+
+    let a = observations(&f, &[1, 5, 2, 9, 4, 8, 3, 7, 6]);
+    let b = observations(&f, &[9, 1, 8, 2, 7, 3, 6, 4, 5]);
+
+    assert_eq!(
+        f.client.compute_daily_index(&a),
+        f.client.compute_daily_index(&b)
+    );
+}
+
+#[test]
+fn aggregating_no_observations_is_rejected() {
+    let f = deploy_initialized();
+
+    assert_eq!(
+        f.client.try_compute_daily_index(&Vec::new(&f.env)),
+        Err(Ok(Error::EmptyObservations))
+    );
+}
+
+#[test]
+fn a_zero_weight_observation_is_rejected() {
+    let f = deploy_initialized();
+
+    let obs = weighted(&f, &[(10, 1), (20, 0)]);
+    assert_eq!(
+        f.client.try_compute_daily_index(&obs),
+        Err(Ok(Error::ZeroWeight))
+    );
+}
+
+#[test]
+fn an_out_of_bounds_observation_is_rejected() {
+    let f = deploy_initialized();
+
+    let obs = weighted(&f, &[(KVI_VALUE_MAX + 1, 1), (20, 1)]);
+    assert_eq!(
+        f.client.try_compute_daily_index(&obs),
+        Err(Ok(Error::ValueOutOfRange))
+    );
+}
+
+/// The aggregated entrypoint stores the computed median and emits the same
+/// CT-035 event, so a consumer acting on the event sees the aggregate.
+#[test]
+fn the_aggregated_entrypoint_stores_the_computed_value_and_emits_the_event() {
+    let f = deploy_initialized();
+
+    let obs = observations(&f, &[10, 20, 30, 40]);
+    let computed = f.client.set_aggregated_index(
+        &solo(&f),
+        &NG,
+        &DATE,
+        &obs,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(computed, 25);
+
+    // Capture the event before any further invocation replaces the buffer.
+    assert_eq!(emitted_count(&f), 1);
+    let expected = DailyIndexUpdated {
+        country: NG,
+        date: DATE,
+        value: 25,
+        basket_version: BASKET,
+        source_period_start: PERIOD_START,
+        source_period_end: PERIOD_END,
+        updater: f.updater.clone(),
+        schema_version: SCHEMA_VERSION,
+    };
+    assert_eq!(f.env.events().all(), expected_event(&f, &expected));
+
+    let stored = f.client.get_daily_index(&NG, &DATE).unwrap();
+    assert_eq!(stored.value, 25);
+    assert_eq!(stored.basket_version, BASKET);
+    assert_eq!(stored.updater, f.updater.clone());
+}
+
+/// The aggregated path shares the CT-033 immutable-history guard.
+#[test]
+fn the_aggregated_entrypoint_enforces_immutable_history() {
+    let f = deploy_initialized();
+    let obs = observations(&f, &[10, 20, 30]);
+
+    f.client.set_aggregated_index(
+        &solo(&f),
+        &NG,
+        &DATE,
+        &obs,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(
+        f.client.try_set_aggregated_index(
+            &solo(&f),
+            &NG,
+            &DATE,
+            &obs,
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::IndexAlreadyFinalized))
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CT-033 — reject duplicate index updates (#508)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A duplicate of an already-finalized day is a replay and must fail, even
+/// with a different value.
+#[test]
+fn replaying_the_same_day_is_rejected() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &solo(&f),
+            &NG,
+            &DATE,
+            &(VALUE + 1),
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::IndexAlreadyFinalized))
+    );
+
+    // The original record is untouched — history is immutable.
+    assert_eq!(f.client.get_daily_index(&NG, &DATE).unwrap().value, VALUE);
+}
+
+#[test]
+fn a_rejected_replay_emits_no_event() {
+    let f = deploy_initialized();
+    set_index(&f);
+
+    assert!(f
+        .client
+        .try_set_daily_index(
+            &solo(&f),
+            &NG,
+            &DATE,
+            &(VALUE + 1),
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        )
+        .is_err());
+
+    assert_eq!(emitted_count(&f), 0);
+}
+
+/// Backdating: once a later day is finalized, an earlier day cannot be
+/// written, and the rejected write stores nothing.
+#[test]
+fn backdating_after_a_later_day_is_rejected() {
+    let f = deploy_initialized();
+    set_index(&f); // NG@DATE
+
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &(DATE + 1),
+        &VALUE,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &solo(&f),
+            &NG,
+            &(DATE - 1),
+            &VALUE,
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::OutOfOrderUpdate))
+    );
+    assert_eq!(f.client.get_daily_index(&NG, &(DATE - 1)), None);
+}
+
+/// History is strictly forward: a gap cannot be backfilled once a later day
+/// exists — a missed day simply has no index.
+#[test]
+fn a_gap_cannot_be_backfilled() {
+    let f = deploy_initialized();
+    set_index(&f); // NG@DATE
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &(DATE + 2),
+        &VALUE,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(
+        f.client.try_set_daily_index(
+            &solo(&f),
+            &NG,
+            &(DATE + 1),
+            &VALUE,
+            &BASKET,
+            &PERIOD_START,
+            &PERIOD_END
+        ),
+        Err(Ok(Error::OutOfOrderUpdate))
+    );
+}
+
+/// Immutability is per country: finalizing one country's day does not lock
+/// any other country's calendar.
+#[test]
+fn immutability_is_per_country() {
+    let f = deploy_initialized();
+    set_index(&f); // NG@DATE
+
+    f.client.set_daily_index(
+        &solo(&f),
+        &symbol_short!("KE"),
+        &DATE,
+        &VALUE,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(
+        f.client
+            .get_daily_index(&symbol_short!("KE"), &DATE)
+            .unwrap()
+            .value,
+        VALUE
+    );
+}
+
+/// Strictly increasing days are accepted; this pins the forward rule that
+/// the out-of-order check implements.
+#[test]
+fn strictly_increasing_days_are_accepted() {
+    let f = deploy_initialized();
+
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &DATE,
+        &100,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &(DATE + 1),
+        &200,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+    f.client.set_daily_index(
+        &solo(&f),
+        &NG,
+        &(DATE + 2),
+        &300,
+        &BASKET,
+        &PERIOD_START,
+        &PERIOD_END,
+    );
+
+    assert_eq!(
+        f.client.get_daily_index(&NG, &(DATE + 2)).unwrap().value,
+        300
     );
 }


### PR DESCRIPTION
Closes #505
Closes #506
Closes #507
Closes #508

Implements the four remaining KovaraIndex issues — **CT-030** (daily storage and queries), **CT-031** (KVI rounding rules), **CT-032** (deterministic aggregation) and **CT-033** (reject duplicate index updates) — in one PR, matching how the earlier CT-034/CT-037 and CT-035/CT-036 pairs landed.

The crate already carried CT-034..CT-037; its README explicitly reserved these four as "Not implemented". This lands them on one shared write path so the entrypoints cannot diverge.

---

## CT-030 — daily KovaraIndex storage (#505)

> *Acceptance: Authorized updates store one index per country/day with query methods and events.*

One record per country/day was already the storage shape; what was missing was the query surface. Adds:

- `latest_daily_index(country)` — most recent finalized day, one read via the per-country latest-date index (no scan);
- `daily_index_history(country, from, to)` — the days in `[from, to]`, ascending, bounded by `MAX_HISTORY_WINDOW` (10 years) so the query cannot be weaponized into an unbounded loop; inverted ranges are explicit errors.

Events were already emitted per write (CT-035); `latest`/`history` plus the existing single-day read complete the query surface.

## CT-031 — KVI rounding rules (#506)

> *Acceptance: Scale, rounding, overflow, missing-basket, and baseline rules are documented/tested.*

- **Scale** — `KVI_SCALE = 10_000`: `value / 10_000` is the human-readable index.
- **Rounding** — the one rule is **half away from zero** (`5/2 → 3`, `-5/2 → -3`), applied wherever a division can go fractional (the even-count median average). Symmetric, never directionally biased.
- **Overflow** — values outside `±KVI_VALUE_MAX` (10^18) are rejected with `ValueOutOfRange`; the bound keeps every arithmetic step far inside `i128`.
- **Missing basket** — `basket_version == 0` rejected; an unfinalized day reads as `None` (zero is never a stand-in for "no data").
- **Baseline** — `KVI_BASELINE = 100 * KVI_SCALE` (100.0000) pins what "parity with the reference period" means.

## CT-032 — deterministic aggregation (#507)

> *Acceptance: Median, threshold, weighting, and tie behavior are deterministic for identical inputs.*

`compute_daily_index(observations)` is a pure, stateless **weighted, 10%-trimmed median**:

1. **Trim** — drop the lowest/highest `len * 10 / 100` observations (floored).
2. **Sort** — ascending by value only; equal values interchangeable.
3. **Weighted median** — first value whose cumulative weight exceeds half the total; an **exact half** averages the two straddling values with the CT-031 rounding.

The result depends only on the multiset of `(value, weight)` pairs — never on input order, submitter, or ledger state. `set_aggregated_index(...)` computes with the same function, stores, and emits the CT-035 event, returning the computed value. Empty and zero-weight inputs are rejected.

## CT-033 — reject duplicate index updates (#508)

> *Acceptance: Duplicate and out-of-order updates follow documented immutable-history rules.*

- **Duplicates** — a `(country, date)` with a record fails with `IndexAlreadyFinalized`: replaying an update (even with a different value) cannot overwrite a finalized day.
- **Out-of-order** — a date at or before the country's latest finalized date fails with `OutOfOrderUpdate`: history moves strictly forward, a missed day is a day with no index, and gaps cannot be backfilled later.

Both checks run in the same write path as the record and the per-country latest-date index, so the guard and the data cannot diverge. Rejected updates emit no event and store nothing.

---

## Tests — 97 passing (was 68)

29 new tests: latest/history queries and range bounds; scale/baseline/rounding pins and value bounds; median, even-count rounding, trimming, weighting, tie and order-independence determinism plus the aggregated entrypoint; replay, backdate, gap and per-country immutability. Two existing rotation tests now write a fresh day, since `NG@DATE` became immutable after its first write.

```
cargo test  -p kovara-index                                  97 passed, 0 failed
cargo fmt   -p kovara-index -- --check                       clean
cargo clippy -p kovara-index --all-targets                   no warnings
cargo build -p kovara-index --target wasm32v1-none --release kovara_index.wasm
```

Build for **`wasm32v1-none`** (not `wasm32-unknown-unknown`), matching the established convention in this crate.