### PR TITLE
Post

### DIFF
--- a/Backend/migrations/002_posts.sql
+++ b/Backend/migrations/002_posts.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS posts (
     content TEXT NOT NULL,
     tip_total BIGINT NOT NULL DEFAULT 0,
     like_count BIGINT NOT NULL DEFAULT 0,
+    created_ledger INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP DEFAULT NULL,
     

--- a/Backend/migrations/007_post_created_ledger.sql
+++ b/Backend/migrations/007_post_created_ledger.sql
@@ -1,0 +1,5 @@
+-- Migration: Persist the ledger that created each post
+-- Description: Adds created_ledger for databases initialized before the field existed
+
+ALTER TABLE posts
+  ADD COLUMN IF NOT EXISTS created_ledger INTEGER NOT NULL DEFAULT 0;

--- a/Backend/src/__tests__/db.test.ts
+++ b/Backend/src/__tests__/db.test.ts
@@ -1,0 +1,75 @@
+import { Pool } from "pg";
+import { PostgresDatabase } from "../db";
+
+describe("PostgresDatabase.insertPost", () => {
+  const postRow = {
+    id: "7",
+    author: "GAUTHOR",
+    content: "hello",
+    tip_total: "12",
+    like_count: "3",
+    created_ledger: 456,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    deleted_at: null,
+  };
+
+  const post = {
+    id: 7n,
+    author: "GAUTHOR",
+    content: "hello",
+    deleted: false,
+    tip_total: 12n,
+    like_count: 3n,
+    created_ledger: 456,
+    deleted_ledger: null,
+  };
+
+  it("persists and reads the post creation ledger", async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [postRow] });
+    const database = new PostgresDatabase({ query } as unknown as Pool);
+
+    await database.insertPost(post);
+
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("created_ledger, created_at"),
+      ["7", "GAUTHOR", "hello", "12", "3", 456, null]
+    );
+    await expect(database.getPost(7n)).resolves.toMatchObject({
+      created_ledger: 456,
+      tip_total: 12n,
+      like_count: 3n,
+    });
+  });
+
+  it("keeps a cached post when the write fails", async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [postRow] })
+      .mockRejectedValueOnce(new Error("write failed"));
+    const database = new PostgresDatabase({ query } as unknown as Pool);
+
+    await database.getPost(7n);
+    await expect(database.incrementPostLikeCount(7n)).rejects.toThrow("write failed");
+    await expect(database.getPost(7n)).resolves.toMatchObject({ like_count: 3n });
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates a cached post after a successful write", async () => {
+    const refreshedRow = { ...postRow, like_count: "4" };
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [postRow] })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [refreshedRow] });
+    const database = new PostgresDatabase({ query } as unknown as Pool);
+
+    await database.getPost(7n);
+    await database.incrementPostLikeCount(7n);
+    await expect(database.getPost(7n)).resolves.toMatchObject({ like_count: 4n });
+    expect(query).toHaveBeenCalledTimes(3);
+  });
+});

--- a/Backend/src/db.ts
+++ b/Backend/src/db.ts
@@ -296,8 +296,8 @@ export class PostgresDatabase implements Database {
     this.postCache.delete(post.id.toString());
     await this.runQuery(
       `
-      INSERT INTO posts (id, author, content, tip_total, like_count, created_at)
-      VALUES ($1, $2, $3, $4, $5, COALESCE($6, NOW()))
+      INSERT INTO posts (id, author, content, tip_total, like_count, created_ledger, created_at)
+      VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7, NOW()))
       ON CONFLICT (id) DO NOTHING
       `,
       [
@@ -306,6 +306,7 @@ export class PostgresDatabase implements Database {
         post.content,
         post.tip_total.toString(),
         post.like_count.toString(),
+        post.created_ledger,
         post.created_at ?? null,
       ]
     );

--- a/Backend/src/db.ts
+++ b/Backend/src/db.ts
@@ -194,10 +194,9 @@ export class PostgresDatabase implements Database {
   // In-memory caches for frequently-queryable records (BE-18).
   // Short TTL balances read performance with eventual consistency.
   //
-  // Cache invalidation strategy (BE-33): Every write method that mutates a
-  // cached entity deletes the corresponding cache entry *before* issuing the
-  // SQL statement. This ensures that any subsequent read will fetch the latest
-  // committed state from Postgres rather than returning a stale cached value.
+  // Cache invalidation strategy (BE-33): Every successful write method that
+  // mutates a cached entity deletes the corresponding cache entry after the
+  // SQL statement completes. Failed writes preserve the valid cached value.
   // The TTL acts as a safety net for entries that were not explicitly invalidated.
   private readonly profileCache = new TTLCache<Profile>(30_000); // 30 seconds
   private readonly postCache = new TTLCache<Post>(30_000);
@@ -244,9 +243,6 @@ export class PostgresDatabase implements Database {
   }
 
   async upsertProfile(profile: Profile): Promise<void> {
-    // Invalidates any cached version of this profile so the next read
-    // fetches fresh data (BE-18).
-    this.profileCache.delete(profile.address);
     await this.runQuery(
       `
       INSERT INTO profiles (address, username, creator_token, updated_ledger)
@@ -258,6 +254,7 @@ export class PostgresDatabase implements Database {
       `,
       [profile.address, profile.username, profile.creator_token, profile.updated_ledger]
     );
+    this.profileCache.delete(profile.address);
   }
 
   async getFollow(follower: string, followee: string): Promise<Follow | null> {
@@ -293,7 +290,6 @@ export class PostgresDatabase implements Database {
   }
 
   async insertPost(post: Post): Promise<void> {
-    this.postCache.delete(post.id.toString());
     await this.runQuery(
       `
       INSERT INTO posts (id, author, content, tip_total, like_count, created_ledger, created_at)
@@ -310,10 +306,10 @@ export class PostgresDatabase implements Database {
         post.created_at ?? null,
       ]
     );
+    this.postCache.delete(post.id.toString());
   }
 
   async markPostDeleted(post_id: bigint, deleted_ledger: number, deleted_at?: Date): Promise<void> {
-    this.postCache.delete(post_id.toString());
     await this.runQuery(
       `
       UPDATE posts
@@ -322,21 +318,22 @@ export class PostgresDatabase implements Database {
       `,
       [post_id.toString(), deleted_ledger, deleted_at ?? null]
     );
+    this.postCache.delete(post_id.toString());
   }
 
   async incrementPostLikeCount(post_id: bigint): Promise<void> {
-    this.postCache.delete(post_id.toString());
     await this.runQuery(`UPDATE posts SET like_count = like_count + 1 WHERE id = $1`, [
       post_id.toString(),
     ]);
+    this.postCache.delete(post_id.toString());
   }
 
   async addPostTipTotal(post_id: bigint, net_amount: bigint): Promise<void> {
-    this.postCache.delete(post_id.toString());
     await this.runQuery(`UPDATE posts SET tip_total = tip_total + $2 WHERE id = $1`, [
       post_id.toString(),
       net_amount.toString(),
     ]);
+    this.postCache.delete(post_id.toString());
   }
 
   async getPost(post_id: bigint): Promise<Post | null> {

--- a/Backend/src/db.ts
+++ b/Backend/src/db.ts
@@ -306,6 +306,7 @@ export class PostgresDatabase implements Database {
         post.content,
         post.tip_total.toString(),
         post.like_count.toString(),
+        post.created_at ?? null,
       ]
     );
   }

--- a/Backend/src/handlers/follow.ts
+++ b/Backend/src/handlers/follow.ts
@@ -13,6 +13,16 @@ export interface UnfollowEvent {
   ledger: number;
 }
 
+
+export interface TrendEvent {
+  eventTime: string;
+  events: string;
+  proceeding: number;
+}
+
+
+
+
 /**
  * Handle a Follow event.
  *


### PR DESCRIPTION
 BA-022 — Enforce unique on-chain tips
Type: Bug Fix
Affected area: Backend/migrations/*, insertTip
Summary: Tip idempotency needs a uniqueness rule tied to transaction and event identity.
Acceptance criteria: Replayed tip events create one row and one aggregate update.

BA-025 — Invalidate caches after successful writes
Type: Bug Fix
Affected area: Backend/src/db.ts, TTL caches
Summary: Failed writes unnecessarily discard valid cached state because invalidation happens first.
Acceptance criteria: Invalidation occurs after success or is restored on failure; both cases are tested.

closes #457
closes #460 
closes #459 
closes #458