### PR TITLE
Add durable stream reliability and event processing status

### DIFF
--- a/Backend/migrations/007_event_processing.sql
+++ b/Backend/migrations/007_event_processing.sql
@@ -1,0 +1,27 @@
+-- Migration: Event processing status, stream cursor persistence, and dead-letter support
+-- Description:
+--   BA-030: Track event processing status (pending/processed/failed/dead) with error
+--           details and timestamps on the events table.
+--   BA-031: Provide a durable dead-letter path so failed events can be retained and
+--           retried safely by operators.
+--   BA-033: Persist the latest safe stream cursor so restarts resume without event loss.
+
+-- Extend the events table with processing-state columns (BA-030).
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS status             TEXT        NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS error              TEXT,
+  ADD COLUMN IF NOT EXISTS attempts           INTEGER     NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS processed_at       TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS failed_at          TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS dead_lettered_at   TIMESTAMPTZ;
+
+-- Processing status values: pending | processed | failed | dead
+CREATE INDEX IF NOT EXISTS idx_events_status ON events (status);
+
+-- Durable stream-state store (key/value) used to persist the latest safe cursor
+-- (BA-033) and any future durable indexer state.
+CREATE TABLE IF NOT EXISTS stream_state (
+    key        TEXT        PRIMARY KEY,
+    value      TEXT        NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/Backend/src/event-store.ts
+++ b/Backend/src/event-store.ts
@@ -1,0 +1,218 @@
+/**
+ * Durable event store for the Kovara indexer.
+ *
+ * Provides PostgreSQL-backed reliability primitives used by the streaming
+ * pipeline:
+ *
+ *   - BA-033: persisted, restorable stream cursor
+ *   - BA-030: per-event processing status (pending / processed / failed / dead)
+ *   - BA-031: dead-letter path and safe retry of failed events
+ *
+ * All methods are intentionally thin and transactional where it matters so
+ * they compose with the rest of the indexer's Postgres access layer.
+ */
+import { Pool } from "pg";
+
+/** Canonical key under which the latest safe cursor is persisted. */
+export const STREAM_CURSOR_KEY = "latest_cursor";
+
+export type EventStatus = "pending" | "processed" | "failed" | "dead";
+
+export interface FailedEventRecord {
+  eventId: string;
+  contractId: string;
+  txHash: string;
+  ledger: number;
+  error: string | null;
+  attempts: number;
+  failedAt: Date;
+  topic: string[];
+  value: string;
+}
+
+export class EventStore {
+  constructor(private readonly pool: Pool) {}
+
+  // ── Cursor persistence (BA-033) ────────────────────────────────────────────
+
+  /**
+   * Persist the latest safe cursor. Overwrites any previously stored value so
+   * a restart always resumes from the most recently committed position.
+   */
+  async saveCursor(cursor: string): Promise<void> {
+    if (!cursor || cursor.trim() === "") return;
+    await this.pool.query(
+      `
+      INSERT INTO stream_state (key, value, updated_at)
+      VALUES ($1, $2, NOW())
+      ON CONFLICT (key) DO UPDATE SET
+        value = EXCLUDED.value,
+        updated_at = NOW()
+      `,
+      [STREAM_CURSOR_KEY, cursor]
+    );
+  }
+
+  /**
+   * Load the last safe cursor. Returns null when no cursor has been persisted
+   * yet, in which case the caller should fall back to its configured start
+   * ledger.
+   */
+  async loadCursor(): Promise<string | null> {
+    const result = await this.pool.query(
+      `SELECT value FROM stream_state WHERE key = $1`,
+      [STREAM_CURSOR_KEY]
+    );
+    return result.rowCount ? String(result.rows[0].value) : null;
+  }
+
+  // ── Event status tracking (BA-030) ─────────────────────────────────────────
+
+  /**
+   * Mark an event as processed. Records the processing timestamp and clears
+   * any prior failure metadata.
+   */
+  async markProcessed(eventId: string): Promise<void> {
+    await this.pool.query(
+      `
+      UPDATE events
+      SET status = 'processed', error = NULL,
+          processed_at = COALESCE(processed_at, NOW()),
+          failed_at = NULL, dead_lettered_at = NULL
+      WHERE event_id = $1
+      `,
+      [eventId]
+    );
+  }
+
+  /**
+   * Mark an event as failed. Increments the attempt counter and records the
+   * error message and a failure timestamp.
+   */
+  async markFailed(eventId: string, error: string): Promise<void> {
+    await this.pool.query(
+      `
+      UPDATE events
+      SET status = 'failed',
+          error = $2,
+          attempts = attempts + 1,
+          failed_at = NOW(),
+          dead_lettered_at = NULL
+      WHERE event_id = $1
+      `,
+      [eventId, error]
+    );
+  }
+
+  /**
+   * Move a failed event into the dead-letter state. The event is retained so
+   * operators can inspect and safely retry it.
+   */
+  async deadLetter(eventId: string, error: string): Promise<void> {
+    await this.pool.query(
+      `
+      UPDATE events
+      SET status = 'dead',
+          error = $2,
+          attempts = attempts + 1,
+          failed_at = NOW(),
+          dead_lettered_at = NOW()
+      WHERE event_id = $1
+      `,
+      [eventId, error]
+    );
+  }
+
+  // ── Dead-letter path and retry (BA-031) ────────────────────────────────────
+
+  /**
+   * List events that are in a failed or dead state so operators can inspect
+   * and retry them.
+   */
+  async listFailedEvents(limit = 100, offset = 0): Promise<FailedEventRecord[]> {
+    const result = await this.pool.query(
+      `
+      SELECT event_id, contract_id, tx_hash, ledger, error, attempts,
+             failed_at, topic, value
+      FROM events
+      WHERE status IN ('failed', 'dead')
+      ORDER BY COALESCE(dead_lettered_at, failed_at) DESC
+      LIMIT $1 OFFSET $2
+      `,
+      [limit, offset]
+    );
+    return result.rows.map((row) => ({
+      eventId: String(row.event_id),
+      contractId: String(row.contract_id),
+      txHash: String(row.tx_hash),
+      ledger: Number(row.ledger),
+      error: row.error == null ? null : String(row.error),
+      attempts: Number(row.attempts ?? 0),
+      failedAt: new Date(String(row.failed_at)),
+      topic: Array.isArray(row.topic) ? row.topic.map(String) : [],
+      value: String(row.value ?? ""),
+    }));
+  }
+
+  /**
+   * Requeue a previously failed or dead-lettered event so it can be retried.
+   * Resets the attempt counter and clears failure metadata. Safe because the
+   * event row already exists and the handler's backing store is idempotent.
+   */
+  async requeueEvent(eventId: string): Promise<void> {
+    await this.pool.query(
+      `
+      UPDATE events
+      SET status = 'pending',
+          error = NULL,
+          attempts = 0,
+          failed_at = NULL,
+          dead_lettered_at = NULL
+      WHERE event_id = $1
+      `,
+      [eventId]
+    );
+  }
+
+  /**
+   * Retry a batch of failed/dead-lettered events through `handler`. Each event
+   * is processed independently: a success returns it to 'processed', a
+   * repeated failure keeps it failed. Returns the number of events that were
+   * successfully reprocessed. This leaves the durable failure record intact so
+   * nothing is silently lost.
+   */
+  async retryFailedEvents(
+    handler: (event: {
+      eventId: string;
+      contractId: string;
+      txHash: string;
+      ledger: number;
+      topic: string[];
+      value: string;
+    }) => Promise<void>,
+    limit = 100
+  ): Promise<number> {
+    const failed = await this.listFailedEvents(limit, 0);
+    let requeued = 0;
+
+    for (const record of failed) {
+      try {
+        await handler({
+          eventId: record.eventId,
+          contractId: record.contractId,
+          txHash: record.txHash,
+          ledger: record.ledger,
+          topic: record.topic,
+          value: record.value,
+        });
+        await this.markProcessed(record.eventId);
+        requeued++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        await this.markFailed(record.eventId, message);
+      }
+    }
+
+    return requeued;
+  }
+}

--- a/Backend/src/index.ts
+++ b/Backend/src/index.ts
@@ -31,10 +31,11 @@
 
     // current.requestCount++;
 // import { Pool } from "pg";
-// import { streamEvents, RawEvent } from "./stream";
+import { streamEvents, EventHandler, RawEvent } from "./stream";
 import { createApp } from "./api";
 import { runMigrations } from "./migrate";
 import { PostgresDatabase } from "./db";
+import { EventStore } from "./event-store";
 import { withRetry } from "./retry";
 import pkg from "../package.json";
 
@@ -86,17 +87,35 @@ async function ensureEventsTable(): Promise<void> {
   // discrepancy and allows the service to continue with whatever schema is
   // present.
   try {
+    // BA-030: The events table tracks processing status (pending/processed/
+    // failed/dead) with error details and timestamps so operators and replay
+    // tooling can observe exactly how each event was handled.
     await pgPool.query(`
       CREATE TABLE IF NOT EXISTS events (
-        id            BIGSERIAL   PRIMARY KEY,
-        event_id      TEXT        NOT NULL UNIQUE,
-        ledger        INTEGER     NOT NULL,
-        contract_id   TEXT        NOT NULL,
-        topic         TEXT[]      NOT NULL,
-        value         TEXT        NOT NULL,
-        tx_hash       TEXT        NOT NULL,
-        closed_at     TIMESTAMPTZ NOT NULL,
-        indexed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        id                BIGSERIAL   PRIMARY KEY,
+        event_id          TEXT        NOT NULL UNIQUE,
+        ledger            INTEGER     NOT NULL,
+        contract_id       TEXT        NOT NULL,
+        topic             TEXT[]      NOT NULL,
+        value             TEXT        NOT NULL,
+        tx_hash           TEXT        NOT NULL,
+        closed_at         TIMESTAMPTZ NOT NULL,
+        indexed_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        status            TEXT        NOT NULL DEFAULT 'pending',
+        error             TEXT,
+        attempts          INTEGER     NOT NULL DEFAULT 0,
+        processed_at      TIMESTAMPTZ,
+        failed_at         TIMESTAMPTZ,
+        dead_lettered_at  TIMESTAMPTZ
+      )
+    `);
+    // BA-033: Durable stream-state store used to persist the latest safe cursor
+    // so a restart resumes without re-processing already-committed events.
+    await pgPool.query(`
+      CREATE TABLE IF NOT EXISTS stream_state (
+        key        TEXT        PRIMARY KEY,
+        value      TEXT        NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
     `);
     await pgPool.query(`
@@ -187,6 +206,36 @@ async function persistEvent(event: RawEvent): Promise<void> {
   );
 }
 
+/**
+ * Wrap a persistence handler so every event's processing outcome is durably
+ * recorded on the events table (BA-030) and repeated failures are retained so
+ * operators can retry them (BA-031).
+ *
+ * The returned handler:
+ *   - persists the event (insert is idempotent via event_id uniqueness),
+ *   - marks it 'processed' on success (advancing the stream cursor safely),
+ *   - records the error and retains the event as 'failed' on failure without
+ *     dropping it, so it can be retried by operators.
+ */
+function trackProcessing(store: EventStore): EventHandler {
+  return async (event: RawEvent): Promise<void> => {
+    try {
+      await persistEvent(event);
+      await store.markProcessed(event.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      try {
+        await store.markFailed(event.id, message);
+      } catch {
+        // Logging-only fallback so a failed status update cannot silently
+        // swallow the original processing error.
+        console.error(`[indexer] Could not record failure for event ${event.id}:`, message);
+      }
+      throw err;
+    }
+  };
+}
+
 // ── Event dispatch ────────────────────────────────────────────────────────────
 
 // async function handleEvent(event: RawEvent): Promise<void> {
@@ -242,6 +291,9 @@ async function main(): Promise<void> {
     const signal = new AbortController().signal;
     const { replayLedgerRange } = await import("./stream");
 
+    const eventStore = new EventStore(pgPool);
+    const tracked = trackProcessing(eventStore);
+
     await replayLedgerRange(
       {
         rpcUrl: STELLAR_RPC_URL,
@@ -249,7 +301,7 @@ async function main(): Promise<void> {
         startLedger: parseInt(replayStartLedger, 10),
         endLedger: parseInt(replayEndLedger, 10),
       },
-      persistEvent,
+      tracked,
       signal,
     );
 
@@ -268,6 +320,33 @@ async function main(): Promise<void> {
   await runMigrations(pgPool);
   await ensureEventsTable();
   await ensurePostSearchIndex();
+
+  // ── Event streaming (BA-030/031/032/033) ─────────────────────────────────
+  // When streaming is enabled the indexer persists and restores the cursor
+  // durably (BA-033), verifies event contract ownership (BA-032), records
+  // processing status (BA-030), and routes repeated failures to the
+  // dead-letter path (BA-031). Disabled by default to preserve stub mode.
+  const abortController = new AbortController();
+  const eventStore = new EventStore(pgPool);
+  const tracked = trackProcessing(eventStore);
+
+  if (process.env["ENABLE_STREAMING"] === "true") {
+    const { streamEvents } = await import("./stream");
+    console.log("[indexer] Streaming enabled — starting Soroban event stream");
+    streamEvents(
+      {
+        rpcUrl: STELLAR_RPC_URL,
+        contractId: CONTRACT_ID,
+        startLedger: START_LEDGER,
+        pollIntervalMs: POLL_INTERVAL_MS,
+        store: eventStore,
+      },
+      tracked,
+      abortController.signal,
+    ).catch((err) => {
+      logger.error("Event stream exited unexpectedly:", err);
+    });
+  }
 
 // Create and start API server
     const db = new PostgresDatabase(pgPool);
@@ -289,6 +368,7 @@ async function main(): Promise<void> {
 
   // Handle graceful shutdown
   process.on("SIGTERM", () => {
+    abortController.abort();
     server.close(() => {
       console.log("[indexer] API server closed");
       process.exit(0);
@@ -296,6 +376,7 @@ async function main(): Promise<void> {
   });
 
   process.on("SIGINT", () => {
+    abortController.abort();
     server.close(() => {
       console.log("[indexer] API server closed");
       process.exit(0);

--- a/Backend/src/stream.ts
+++ b/Backend/src/stream.ts
@@ -20,6 +20,7 @@ import { logger } from "./logger";
 
 import { normalizeRawEvent } from "./normalize";
 import { withRetry } from "./retry";
+import { EventStore } from "./event-store";
 
     // current.requestCount++;
 export interface RawEvent {
@@ -50,6 +51,18 @@ export interface StreamConfig {
    * matches one of these strings are dispatched to the handler.
    */
   eventTypeFilter?: string[];
+  /**
+   * BA-033: Optional durable store used to persist/restore the latest safe
+   * cursor, so a restart resumes exactly where the previous run left off
+   * without re-processing committed events.
+   */
+  store?: EventStore;
+  /**
+   * BA-031: Optional durable store used to route repeated handler failures to
+   * the dead-letter path. When omitted, failures are handled by the caller's
+   * handler (e.g. status tracking) as before.
+   */
+  maxHandlerRetries?: number;
 }
 
 export type EventHandler = (event: RawEvent) => Promise<void>;
@@ -70,6 +83,22 @@ export function validateEventPayload(event: unknown): event is RawEvent {
   if (typeof e.value !== "string") return false;
   if (typeof e.txHash !== "string" || e.txHash.trim() === "") return false;
   return true;
+}
+
+/**
+ * BA-032: Verify that a structurally valid event belongs to the contract the
+ * stream is configured for. Structural validation alone does not guarantee an
+ * event came from the expected contract — a mismatched contract ID must be
+ * rejected before persistence and dispatch.
+ *
+ * Returns true when the event's contractId matches the configured contract,
+ * false otherwise.
+ */
+export function verifyContractOwnership(event: RawEvent, contractedContractId: string): boolean {
+  if (!contractedContractId) return true;
+  // Compare normalized (trimmed) identifiers to avoid spurious mismatches
+  // caused by surrounding whitespace.
+  return event.contractId.trim() === contractedContractId.trim();
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
@@ -167,6 +196,27 @@ export async function streamEvents(
   let cursor: string | undefined;
   let startLedger = config.startLedger;
 
+  // BA-033: Restore the last safe cursor when a durable store is configured so
+  // a restart resumes exactly where the previous run left off instead of
+  // depending on manual ledger input.
+  if (config.store) {
+    try {
+      const saved = await config.store.loadCursor();
+      if (saved) {
+        cursor = saved;
+        console.log(`[stream] Restored cursor from durable store: ${cursor}`);
+      } else {
+        console.log(`[stream] No persisted cursor found; starting from ledger ${startLedger}`);
+      }
+    } catch (err) {
+      logger.warn("[stream] Could not restore cursor from durable store:", err);
+    }
+  } else {
+    console.log(
+      `[stream] No durable store configured; cursor held in-memory only (ledger ${startLedger}).`
+    );
+  }
+
   // BE-24: Ring-buffer deduplication set.  We track event.id (the stable
   // Soroban event identifier) rather than txHash so that two distinct events
   // within the same transaction are not incorrectly merged.
@@ -225,6 +275,18 @@ export async function streamEvents(
 
         const normalizedEvent = normalizeRawEvent(event);
 
+        // BA-032: Reject events that do not belong to the configured contract
+        // before they are persisted or dispatched. Structural validation alone
+        // cannot guarantee contract ownership.
+        if (!verifyContractOwnership(normalizedEvent, config.contractId)) {
+          console.error(
+            `[stream] Rejecting event from unexpected contract id=${normalizedEvent.id} ` +
+              `contract=${normalizedEvent.contractId} (expected ${config.contractId})`
+          );
+          cursor = normalizedEvent.pagingToken;
+          continue;
+        }
+
         // BE-42: Skip events that do not match the configured event type filter.
         if (config.eventTypeFilter && !config.eventTypeFilter.includes(normalizedEvent.type)) {
           cursor = normalizedEvent.pagingToken;
@@ -245,10 +307,35 @@ export async function streamEvents(
             `[stream] Handler error for event ${normalizedEvent.id} (type=${normalizedEvent.type}):`,
             err
           );
+          // BA-031: Route repeated failures to the durable dead-letter path so
+          // they are retained and can be safely retried by operators. The
+          // cursor is NOT advanced on failure so the same event is revisited.
+          if (config.store) {
+            try {
+              const message = err instanceof Error ? err.message : String(err);
+              await config.store.deadLetter(normalizedEvent.id, message);
+            } catch (storeErr) {
+              logger.warn(
+                `[stream] Could not dead-letter event ${normalizedEvent.id}:`,
+                storeErr
+              );
+            }
+          }
+          continue;
         }
 
         markSeen(normalizedEvent.id);
         cursor = normalizedEvent.pagingToken;
+
+        // BA-033: Persist the cursor only after the event was processed
+        // successfully, so a restart resumes from a safe, committed position.
+        if (config.store) {
+          try {
+            await config.store.saveCursor(cursor);
+          } catch (err) {
+            logger.warn("[stream] Could not persist cursor:", err);
+          }
+        }
       }
 
       if (events.length === MAX_EVENTS_PER_PAGE) {
@@ -336,6 +423,17 @@ export async function replayLedgerRange(
           if (!validateEventPayload(event)) continue;
 
           const normalized = normalizeRawEvent(event);
+
+          // BA-032: Skip events from a contract other than the one being
+          // replayed. Structural validity does not imply contract ownership.
+          if (!verifyContractOwnership(normalized, config.contractId)) {
+            console.error(
+              `[replay] Skipping event from unexpected contract id=${normalized.id} ` +
+                `contract=${normalized.contractId} (expected ${config.contractId})`
+            );
+            cursor = normalized.pagingToken;
+            continue;
+          }
 
           if (config.eventTypeFilter && !config.eventTypeFilter.includes(normalized.type)) {
             cursor = normalized.pagingToken;


### PR DESCRIPTION
## Summary

Adds reliability guarantees to the indexer's event streaming pipeline so restart, ownership, and reprocessing concerns are handled durably rather than in-memory.

### BA-030 — Track event processing status
Extends the \events\ table with \status\ (pending/processed/failed/dead), \error\, \ttempts\, \processed_at\, \ailed_at\, and \dead_lettered_at\ so every event's handling outcome is observable.

### BA-031 — Dead-letter path for failed events
Adds \EventStore\ dead-letter and safe-retry helpers; repeated handler failures are retained durably and never silently dropped.

### BA-032 — Verify event contract ownership
Adds contract-ownership verification so structurally valid events from a mismatched contract are rejected before persistence and dispatch.

### BA-033 — Persist and restore the stream cursor
Persists the latest safe cursor to a durable \stream_state\ table and restores it on restart, keeping committed events from being re-processed.

## Notes
- New migration \