### PR TITLE
fix: require and validate PostgreSQL, contract, and start-ledger config

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -8,7 +8,10 @@ DATABASE_URL=postgresql://Kovara:Kovara@postgres:5432/Kovara
 
 # Stellar
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
-CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# Required. Replace with the deployed Kovara contract address: a 56-character
+# Stellar strkey beginning with C. Startup fails if this is missing or malformed.
+CONTRACT_ID=
+# Optional, defaults to 0. Must be a non-negative integer ledger sequence.
 START_LEDGER=0
 
 # Indexer API

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -14,7 +14,7 @@ The indexer listens to Stellar contract events and processes them into a Postgre
 
 The following describes the main runtime flow from startup through event handling:
 
-1. **Configuration loading** (`src/index.ts`): Environment variables are validated and parsed. Required variables (`DATABASE_URL`, `STELLAR_RPC_URL`, `CONTRACT_ID`, `START_LEDGER`) must be set; optional variables have sensible defaults.
+1. **Configuration loading** (`src/config.ts`): Environment variables are validated and parsed before anything else runs. `DATABASE_URL` (which must be a `postgres://`/`postgresql://` connection string) and `CONTRACT_ID` (a 56-character Stellar `C…` contract strkey, checksum-verified) are required and have no fallback — startup fails immediately if either is missing or malformed. `STELLAR_RPC_URL` (default: Soroban testnet) and `START_LEDGER` (default: `0`, and rejected unless it is a finite non-negative integer) are optional but still validated when set. All configuration problems are reported together in a single error.
 
 2. **Database initialization** (`src/index.ts:60-126`): A PostgreSQL connection pool is created. Three initialization steps run sequentially:
    - `ensureEventsTable()` — Creates the `events` table and supporting indexes if they do not exist (idempotent via `IF NOT EXISTS`).

--- a/Backend/src/__tests__/config.test.ts
+++ b/Backend/src/__tests__/config.test.ts
@@ -1,0 +1,250 @@
+import {
+  ConfigError,
+  DEFAULT_START_LEDGER,
+  DEFAULT_STELLAR_RPC_URL,
+  isValidContractId,
+  loadConfig,
+  parseContractId,
+  parseDatabaseUrl,
+  parseStartLedger,
+  parseStellarRpcUrl,
+} from "../config";
+
+/**
+ * Real Stellar contract addresses (mainnet asset contracts). Used as fixtures
+ * because they carry genuine strkey checksums, which a hand-written string of
+ * the right length would not.
+ */
+const VALID_CONTRACT_ID = "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+const OTHER_VALID_CONTRACT_ID = "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
+
+const VALID_DATABASE_URL = "postgresql://kovara:kovara@localhost:5432/kovara";
+
+/** A fully valid environment, used as the baseline for negative cases. */
+function validEnv(overrides: Record<string, string | undefined> = {}) {
+  return {
+    DATABASE_URL: VALID_DATABASE_URL,
+    STELLAR_RPC_URL: "https://soroban-testnet.stellar.org",
+    CONTRACT_ID: VALID_CONTRACT_ID,
+    START_LEDGER: "1234",
+    ...overrides,
+  };
+}
+
+describe("parseDatabaseUrl", () => {
+  it("accepts a configured PostgreSQL connection string", () => {
+    expect(parseDatabaseUrl(VALID_DATABASE_URL)).toBe(VALID_DATABASE_URL);
+  });
+
+  it("accepts the postgres:// scheme alias and the docker-compose host form", () => {
+    const compose = "postgres://Kovara:Kovara@postgres:5432/Kovara";
+    expect(parseDatabaseUrl(compose)).toBe(compose);
+  });
+
+  it.each([undefined, "", "   "])("fails when DATABASE_URL is %p", (raw) => {
+    expect(() => parseDatabaseUrl(raw)).toThrow(ConfigError);
+    expect(() => parseDatabaseUrl(raw)).toThrow(/DATABASE_URL is required/);
+  });
+
+  it("rejects the sqlite::memory: fallback the indexer cannot actually use", () => {
+    expect(() => parseDatabaseUrl("sqlite::memory:")).toThrow(
+      /must be a PostgreSQL connection string/
+    );
+  });
+
+  it("rejects a non-PostgreSQL database URL", () => {
+    expect(() => parseDatabaseUrl("mysql://user:pw@localhost:3306/kovara")).toThrow(
+      /must be a PostgreSQL connection string/
+    );
+  });
+
+  it("rejects a value that is not a URL at all", () => {
+    expect(() => parseDatabaseUrl("just-a-host-name")).toThrow(/not a valid connection URL/);
+  });
+
+  it("does not leak credentials when reporting a malformed URL", () => {
+    // A bare "//" is a URL parse failure but still carries userinfo.
+    const err = captureConfigError(() => parseDatabaseUrl("//kovara:hunter2@localhost/db"));
+    expect(err.message).not.toContain("hunter2");
+  });
+
+  it("trims surrounding whitespace from an otherwise valid value", () => {
+    expect(parseDatabaseUrl(`  ${VALID_DATABASE_URL}  `)).toBe(VALID_DATABASE_URL);
+  });
+});
+
+describe("isValidContractId", () => {
+  it("accepts real contract addresses", () => {
+    expect(isValidContractId(VALID_CONTRACT_ID)).toBe(true);
+    expect(isValidContractId(OTHER_VALID_CONTRACT_ID)).toBe(true);
+  });
+
+  it("rejects an address whose checksum does not match", () => {
+    // Flip one character in the payload; length and alphabet stay valid.
+    const mutated = `CDW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75`;
+    expect(mutated).toHaveLength(VALID_CONTRACT_ID.length);
+    expect(isValidContractId(mutated)).toBe(false);
+  });
+
+  it("rejects an account address, which is a different strkey type", () => {
+    expect(isValidContractId("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF5")).toBe(
+      false
+    );
+  });
+
+  it("rejects wrong lengths and non-base32 characters", () => {
+    expect(isValidContractId(VALID_CONTRACT_ID.slice(0, 55))).toBe(false);
+    expect(isValidContractId(`${VALID_CONTRACT_ID}A`)).toBe(false);
+    expect(isValidContractId(`C1${VALID_CONTRACT_ID.slice(2)}`)).toBe(false);
+    expect(isValidContractId(VALID_CONTRACT_ID.toLowerCase())).toBe(false);
+  });
+});
+
+describe("parseContractId", () => {
+  it("accepts a configured contract address", () => {
+    expect(parseContractId(VALID_CONTRACT_ID)).toBe(VALID_CONTRACT_ID);
+  });
+
+  it.each([undefined, "", "   "])("fails when CONTRACT_ID is %p", (raw) => {
+    expect(() => parseContractId(raw)).toThrow(/CONTRACT_ID is required/);
+  });
+
+  it("rejects the PLACEHOLDER_CONTRACT_ID fallback", () => {
+    expect(() => parseContractId("PLACEHOLDER_CONTRACT_ID")).toThrow(
+      /not a valid Stellar contract address/
+    );
+  });
+
+  it("rejects the .env.example placeholder shape", () => {
+    expect(() => parseContractId("CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")).toThrow(
+      /not a valid Stellar contract address/
+    );
+  });
+
+  it("rejects a malformed address that is the right length", () => {
+    expect(() => parseContractId("C".repeat(56))).toThrow(/not a valid Stellar contract address/);
+  });
+});
+
+describe("parseStartLedger", () => {
+  it("accepts finite non-negative integers", () => {
+    expect(parseStartLedger("0")).toBe(0);
+    expect(parseStartLedger("1")).toBe(1);
+    expect(parseStartLedger("52340987")).toBe(52340987);
+  });
+
+  it("defaults to the genesis ledger when unset", () => {
+    expect(parseStartLedger(undefined)).toBe(DEFAULT_START_LEDGER);
+    expect(parseStartLedger("")).toBe(DEFAULT_START_LEDGER);
+    expect(parseStartLedger("  ")).toBe(DEFAULT_START_LEDGER);
+  });
+
+  // Regression: parseInt(value, 10) returned NaN or a silently truncated
+  // number for every one of these, and the stream config accepted it.
+  it.each(["abc", "NaN", "", " ", "1e3", "0x10", "Infinity", "1.5", "1_000"])(
+    "rejects the malformed value %p rather than producing NaN",
+    (raw) => {
+      if (raw.trim() === "") return; // covered by the default case above
+      expect(() => parseStartLedger(raw)).toThrow(ConfigError);
+      expect(() => parseStartLedger(raw)).toThrow(/must be a non-negative integer/);
+    }
+  );
+
+  it("rejects a value parseInt would silently truncate", () => {
+    expect(() => parseStartLedger("12abc")).toThrow(/must be a non-negative integer/);
+    expect(() => parseStartLedger("42 ledgers")).toThrow(/must be a non-negative integer/);
+  });
+
+  it.each(["-1", "-100", "+5"])("rejects the negative or signed value %p", (raw) => {
+    expect(() => parseStartLedger(raw)).toThrow(/must be a non-negative integer/);
+  });
+
+  it("rejects integers beyond the safe range", () => {
+    expect(() => parseStartLedger("9".repeat(40))).toThrow(/outside the supported range/);
+  });
+
+  it("names the variable it was given, for reuse on replay bounds", () => {
+    expect(() => parseStartLedger("abc", "REPLAY_START_LEDGER")).toThrow(/REPLAY_START_LEDGER/);
+  });
+});
+
+describe("parseStellarRpcUrl", () => {
+  it("accepts an http(s) endpoint and defaults to testnet", () => {
+    expect(parseStellarRpcUrl("https://rpc.example.org")).toBe("https://rpc.example.org");
+    expect(parseStellarRpcUrl(undefined)).toBe(DEFAULT_STELLAR_RPC_URL);
+  });
+
+  it("rejects a non-http endpoint", () => {
+    expect(() => parseStellarRpcUrl("ftp://rpc.example.org")).toThrow(/http or https/);
+    expect(() => parseStellarRpcUrl("not a url")).toThrow(/not a valid URL/);
+  });
+});
+
+describe("loadConfig", () => {
+  it("returns the parsed configuration for a valid PostgreSQL deployment", () => {
+    expect(loadConfig(validEnv())).toEqual({
+      databaseUrl: VALID_DATABASE_URL,
+      stellarRpcUrl: "https://soroban-testnet.stellar.org",
+      contractId: VALID_CONTRACT_ID,
+      startLedger: 1234,
+    });
+  });
+
+  it("applies defaults only where a default is genuinely safe", () => {
+    const config = loadConfig({
+      DATABASE_URL: VALID_DATABASE_URL,
+      CONTRACT_ID: VALID_CONTRACT_ID,
+    });
+    expect(config.stellarRpcUrl).toBe(DEFAULT_STELLAR_RPC_URL);
+    expect(config.startLedger).toBe(DEFAULT_START_LEDGER);
+  });
+
+  it("fails when DATABASE_URL is missing", () => {
+    expect(() => loadConfig(validEnv({ DATABASE_URL: undefined }))).toThrow(
+      /DATABASE_URL is required/
+    );
+  });
+
+  it("fails when CONTRACT_ID is missing", () => {
+    expect(() => loadConfig(validEnv({ CONTRACT_ID: undefined }))).toThrow(
+      /CONTRACT_ID is required/
+    );
+  });
+
+  it("fails when START_LEDGER is malformed", () => {
+    expect(() => loadConfig(validEnv({ START_LEDGER: "abc" }))).toThrow(
+      /START_LEDGER must be a non-negative integer/
+    );
+  });
+
+  it("reports every problem at once instead of one per restart", () => {
+    const err = captureConfigError(() =>
+      loadConfig({ DATABASE_URL: "sqlite::memory:", CONTRACT_ID: "PLACEHOLDER_CONTRACT_ID", START_LEDGER: "-1" })
+    );
+    expect(err.problems).toHaveLength(3);
+    expect(err.message).toMatch(/DATABASE_URL/);
+    expect(err.message).toMatch(/CONTRACT_ID/);
+    expect(err.message).toMatch(/START_LEDGER/);
+  });
+
+  it("reads process.env by default", () => {
+    const previous = { ...process.env };
+    try {
+      Object.assign(process.env, validEnv({ CONTRACT_ID: OTHER_VALID_CONTRACT_ID }));
+      expect(loadConfig().contractId).toBe(OTHER_VALID_CONTRACT_ID);
+    } finally {
+      process.env = previous as NodeJS.ProcessEnv;
+    }
+  });
+});
+
+/** Run `fn`, asserting it threw a ConfigError, and return it for inspection. */
+function captureConfigError(fn: () => unknown): ConfigError {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof ConfigError) return err;
+    throw err;
+  }
+  throw new Error("Expected a ConfigError to be thrown");
+}

--- a/Backend/src/config.ts
+++ b/Backend/src/config.ts
@@ -1,0 +1,289 @@
+/**
+ * Kovara Indexer — startup configuration.
+ *
+ * Every value the indexer needs before it can do useful work is parsed and
+ * validated here, in one place, with no side effects. The indexer previously
+ * substituted defaults for values it cannot actually run without — a
+ * `sqlite::memory:` connection string for a PostgreSQL-only implementation, a
+ * `PLACEHOLDER_CONTRACT_ID` that matches no contract, and a `parseInt` result
+ * that could be `NaN`. Each of those let the process reach a "ready" state
+ * while being permanently unable to index anything.
+ *
+ * The rule this module enforces: configuration that has no safe default is
+ * required, and a value that is present but unusable is an error rather than a
+ * silent fallback. Failures are collected and reported together so an operator
+ * fixing a `.env` file sees every problem in one pass.
+ */
+
+/** Raised when one or more environment variables are missing or unusable. */
+export class ConfigError extends Error {
+  /** Every individual problem found, in declaration order. */
+  readonly problems: readonly string[];
+
+  constructor(problems: readonly string[]) {
+    const detail = problems.map((p) => `  - ${p}`).join("\n");
+    super(`Invalid indexer configuration:\n${detail}`);
+    this.name = "ConfigError";
+    this.problems = problems;
+  }
+}
+
+/** The validated configuration the indexer starts from. */
+export interface IndexerConfig {
+  databaseUrl: string;
+  stellarRpcUrl: string;
+  contractId: string;
+  startLedger: number;
+}
+
+/** A `process.env`-shaped source of raw values. */
+export type EnvSource = Record<string, string | undefined>;
+
+// ── DATABASE_URL ─────────────────────────────────────────────────────────────
+
+/**
+ * PostgreSQL URI schemes accepted by `pg`. Anything else (notably `sqlite:`)
+ * describes a database this indexer cannot talk to.
+ */
+const POSTGRES_SCHEMES = ["postgres:", "postgresql:"];
+
+/**
+ * Validate `DATABASE_URL` as a PostgreSQL connection string.
+ *
+ * There is no meaningful default: the implementation issues PostgreSQL-specific
+ * SQL (`TEXT[]` columns, `TSVECTOR`/GIN search indexes, `ON CONFLICT`), so a
+ * missing value must stop startup rather than fall back to an in-memory SQLite
+ * URL the driver would never reach anyway.
+ */
+export function parseDatabaseUrl(raw: string | undefined): string {
+  const value = raw?.trim() ?? "";
+  if (value === "") {
+    throw new ConfigError([
+      "DATABASE_URL is required — the indexer stores events in PostgreSQL and has no " +
+        "usable default (example: postgresql://user:password@localhost:5432/kovara)",
+    ]);
+  }
+
+  let scheme: string;
+  try {
+    scheme = new URL(value).protocol.toLowerCase();
+  } catch {
+    throw new ConfigError([
+      `DATABASE_URL is not a valid connection URL: "${redactUrl(value)}" ` +
+        "(expected postgresql://user:password@host:port/database)",
+    ]);
+  }
+
+  if (!POSTGRES_SCHEMES.includes(scheme)) {
+    throw new ConfigError([
+      `DATABASE_URL must be a PostgreSQL connection string, but its scheme is "${scheme}". ` +
+        "The indexer only supports PostgreSQL (postgres:// or postgresql://).",
+    ]);
+  }
+
+  return value;
+}
+
+/**
+ * Strip credentials from a connection URL before it appears in an error
+ * message, so a malformed value cannot leak a password into the logs.
+ */
+function redactUrl(value: string): string {
+  const at = value.lastIndexOf("@");
+  if (at === -1) return value;
+  const schemeEnd = value.indexOf("//");
+  const prefix = schemeEnd === -1 ? "" : value.slice(0, schemeEnd + 2);
+  return `${prefix}***${value.slice(at)}`;
+}
+
+// ── CONTRACT_ID ──────────────────────────────────────────────────────────────
+
+/** RFC 4648 base32 alphabet used by Stellar strkey encoding. */
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/** Strkey version byte for a contract address, i.e. `2 << 3`. Encodes as "C". */
+const STRKEY_VERSION_CONTRACT = 2 << 3;
+
+/** 1 version byte + a 32-byte contract hash + a 2-byte checksum. */
+const STRKEY_CONTRACT_BYTES = 35;
+
+/** 35 bytes of payload encode to exactly 56 unpadded base32 characters. */
+const STRKEY_CONTRACT_CHARS = 56;
+
+/** Decode unpadded base32, or return null if the input is not base32. */
+function base32Decode(input: string): Uint8Array | null {
+  const out = new Uint8Array(Math.floor((input.length * 5) / 8));
+  let bits = 0;
+  let value = 0;
+  let index = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const symbol = BASE32_ALPHABET.indexOf(input[i]);
+    if (symbol === -1) return null;
+    value = (value << 5) | symbol;
+    bits += 5;
+    if (bits >= 8) {
+      out[index++] = (value >>> (bits - 8)) & 0xff;
+      bits -= 8;
+    }
+  }
+
+  return out;
+}
+
+/** CRC16-XModem (polynomial 0x1021, zero seed), the strkey checksum. */
+function crc16Xmodem(bytes: Uint8Array): number {
+  let crc = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    crc ^= bytes[i] << 8;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc;
+}
+
+/**
+ * Whether `value` is a well-formed Stellar contract address (a `C…` strkey):
+ * 56 base32 characters carrying the contract version byte, a 32-byte hash and a
+ * valid CRC16 checksum. The checksum is what makes this stronger than a shape
+ * check — it rejects typos and placeholder-looking values that happen to have
+ * the right length and alphabet.
+ */
+export function isValidContractId(value: string): boolean {
+  if (value.length !== STRKEY_CONTRACT_CHARS) return false;
+
+  const decoded = base32Decode(value);
+  if (decoded === null || decoded.length !== STRKEY_CONTRACT_BYTES) return false;
+  if (decoded[0] !== STRKEY_VERSION_CONTRACT) return false;
+
+  const expected = crc16Xmodem(decoded.subarray(0, STRKEY_CONTRACT_BYTES - 2));
+  const actual = decoded[33] | (decoded[34] << 8); // checksum is little-endian
+  return expected === actual;
+}
+
+/**
+ * Validate `CONTRACT_ID`. The indexer streams events for exactly one contract,
+ * so an absent or malformed address makes every subsequent RPC call useless;
+ * both cases fail here rather than after the process reports itself ready.
+ */
+export function parseContractId(raw: string | undefined): string {
+  const value = raw?.trim() ?? "";
+  if (value === "") {
+    throw new ConfigError([
+      "CONTRACT_ID is required — set it to the deployed Kovara contract address " +
+        "(a 56-character Stellar address beginning with C)",
+    ]);
+  }
+
+  if (!isValidContractId(value)) {
+    throw new ConfigError([
+      `CONTRACT_ID is not a valid Stellar contract address: "${value}". ` +
+        "Expected a 56-character strkey beginning with C (for example " +
+        "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75).",
+    ]);
+  }
+
+  return value;
+}
+
+// ── START_LEDGER ─────────────────────────────────────────────────────────────
+
+/** Ledger sequence used when `START_LEDGER` is not set: stream from genesis. */
+export const DEFAULT_START_LEDGER = 0;
+
+/**
+ * Parse `START_LEDGER` as a ledger sequence number.
+ *
+ * `parseInt` is deliberately not used on its own: it yields `NaN` for "abc" and
+ * silently truncates "12abc" to 12, and the stream configuration accepts both
+ * without complaint. Only a finite, non-negative, safe integer is allowed; an
+ * unset value falls back to {@link DEFAULT_START_LEDGER}, which is a genuine
+ * default rather than a stand-in for a missing value.
+ */
+export function parseStartLedger(
+  raw: string | undefined,
+  name = "START_LEDGER"
+): number {
+  const value = raw?.trim() ?? "";
+  if (value === "") return DEFAULT_START_LEDGER;
+
+  if (!/^\d+$/.test(value)) {
+    throw new ConfigError([
+      `${name} must be a non-negative integer ledger sequence, but was "${raw}"`,
+    ]);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new ConfigError([
+      `${name} is outside the supported range of ledger sequences: "${raw}"`,
+    ]);
+  }
+
+  return parsed;
+}
+
+// ── STELLAR_RPC_URL ──────────────────────────────────────────────────────────
+
+/** Public Soroban RPC used when `STELLAR_RPC_URL` is not set. */
+export const DEFAULT_STELLAR_RPC_URL = "https://soroban-testnet.stellar.org";
+
+/** Validate `STELLAR_RPC_URL` as an http(s) endpoint, defaulting to testnet. */
+export function parseStellarRpcUrl(raw: string | undefined): string {
+  const value = raw?.trim() ?? "";
+  if (value === "") return DEFAULT_STELLAR_RPC_URL;
+
+  let scheme: string;
+  try {
+    scheme = new URL(value).protocol.toLowerCase();
+  } catch {
+    throw new ConfigError([`STELLAR_RPC_URL is not a valid URL: "${value}"`]);
+  }
+
+  if (scheme !== "http:" && scheme !== "https:") {
+    throw new ConfigError([
+      `STELLAR_RPC_URL must be an http or https endpoint, but was "${value}"`,
+    ]);
+  }
+
+  return value;
+}
+
+// ── Aggregate ────────────────────────────────────────────────────────────────
+
+/**
+ * Validate every startup-critical variable and return the resulting config.
+ *
+ * All problems are collected before throwing so a misconfigured deployment is
+ * reported in one message instead of one restart per mistake.
+ */
+export function loadConfig(env: EnvSource = process.env): IndexerConfig {
+  const problems: string[] = [];
+
+  const collect = <T>(parse: () => T): T | undefined => {
+    try {
+      return parse();
+    } catch (err) {
+      if (err instanceof ConfigError) {
+        problems.push(...err.problems);
+        return undefined;
+      }
+      throw err;
+    }
+  };
+
+  const databaseUrl = collect(() => parseDatabaseUrl(env.DATABASE_URL));
+  const stellarRpcUrl = collect(() => parseStellarRpcUrl(env.STELLAR_RPC_URL));
+  const contractId = collect(() => parseContractId(env.CONTRACT_ID));
+  const startLedger = collect(() => parseStartLedger(env.START_LEDGER));
+
+  if (problems.length > 0) throw new ConfigError(problems);
+
+  return {
+    databaseUrl: databaseUrl as string,
+    stellarRpcUrl: stellarRpcUrl as string,
+    contractId: contractId as string,
+    startLedger: startLedger as number,
+  };
+}

--- a/Backend/src/index.ts
+++ b/Backend/src/index.ts
@@ -7,10 +7,10 @@
  * for querying indexed data.
  *
  * Environment variables (all required unless noted):
- *   DATABASE_URL           - PostgreSQL connection string
- *   STELLAR_RPC_URL        - Soroban RPC endpoint
- *   CONTRACT_ID            - Bech32 contract address
- *   START_LEDGER           - Ledger sequence to start streaming from
+ *   DATABASE_URL           - PostgreSQL connection string (required)
+ *   CONTRACT_ID            - Stellar contract address, a 56-char C… strkey (required)
+ *   STELLAR_RPC_URL        - (optional) Soroban RPC endpoint, default testnet
+ *   START_LEDGER           - (optional) Ledger sequence to stream from, default 0
  *   HOST                   - (optional) API server host, default 0.0.0.0
  *   PORT                   - (optional) API server port, default 3000
  *   TRUST_PROXY            - (optional) Number of proxies to trust (for X-Forwarded-For), default 0 (disabled)
@@ -20,34 +20,20 @@
  *   ENABLE_AUTH_MIDDLEWARE - (optional) Enable authentication middleware (default: false)
  *   ENABLE_RATE_LIMITING   - (optional) Enable rate limiting middleware (default: true)
  *   ENABLE_EXPERIMENTAL_ROUTES - (optional) Enable experimental routes (e.g., pools) (default: false)
-//  */.....
-/**
- * Handle a Follow event.
- *
- * Inserts a directed edge (follower → followee) into the follow graph.
- * Idempotent: if the follow already exists the handler returns immediately
- * without issuing a database write.
  */
-
-    // current.requestCount++;
-// import { Pool } from "pg";
+import { Pool } from "pg";
 import { streamEvents, EventHandler, RawEvent } from "./stream";
-import { createApp } from "./api";
+import { createApp, AuthMiddleware } from "./api";
 import { runMigrations } from "./migrate";
 import { PostgresDatabase } from "./db";
 import { EventStore } from "./event-store";
 import { withRetry } from "./retry";
 import { logger } from "./logger";
 import { randomUUID } from "crypto";
+import { ConfigError, IndexerConfig, loadConfig, parseStartLedger } from "./config";
 import pkg from "../package.json";
 
 // ── Config ────────────────────────────────────────────────────────────────────
-
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) throw new Error(`Missing required environment variable: ${name}`);
-  return value;
-}
 
 function parseEnvNumber(name: string, defaultValue: number): number {
   const value = process.env[name];
@@ -66,36 +52,56 @@ function parseEnvNumber(name: string, defaultValue: number): number {
  * integer, so malformed replay configuration fails fast.
  */
 function parseLedger(raw: string, name: string): number {
-  const trimmed = raw?.trim() ?? "";
-  if (trimmed === "") {
+  if ((raw?.trim() ?? "") === "") {
     throw new Error(`Missing required environment variable: ${name}`);
   }
-  if (!/^\d+$/.test(trimmed)) {
-    throw new Error(
-      `Invalid ledger value for ${name}: "${raw}" is not an integer. Ledger ranges are ` +
-        `inclusive on both ends and must be non-negative.`
-    );
-  }
-  const parsed = parseInt(trimmed, 10);
-  if (!Number.isSafeInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid ledger value for ${name}: "${raw}" is out of supported bounds.`);
-  }
-  return parsed;
+  // Shares parseStartLedger's validation so a replay bound and START_LEDGER
+  // accept exactly the same values.
+  return parseStartLedger(raw, name);
 }
 
 const HOST = process.env.HOST ?? "0.0.0.0";
 const PORT = parseEnvNumber("PORT", 3000);
 
-const DATABASE_URL = process.env.DATABASE_URL || "sqlite::memory:";
-const STELLAR_RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
-const CONTRACT_ID = process.env.CONTRACT_ID || "PLACEHOLDER_CONTRACT_ID";
-const START_LEDGER = parseInt(process.env.START_LEDGER || "0", 10);
+/**
+ * Validate every startup-critical variable before anything else runs.
+ *
+ * This deliberately happens at module scope, ahead of the connection pool and
+ * any migration or RPC work: a missing DATABASE_URL, an absent or malformed
+ * CONTRACT_ID, or a non-numeric START_LEDGER used to be papered over with
+ * defaults that produced an indexer which started successfully and then could
+ * never index anything. Every problem is reported together so one restart is
+ * enough to see them all.
+ */
+function loadStartupConfig(): IndexerConfig {
+  try {
+    return loadConfig();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      logger.always("config_invalid", { problems: err.problems });
+      console.error(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+const {
+  databaseUrl: DATABASE_URL,
+  stellarRpcUrl: STELLAR_RPC_URL,
+  contractId: CONTRACT_ID,
+  startLedger: START_LEDGER,
+} = loadStartupConfig();
+
 const POLL_INTERVAL_MS = parseEnvNumber("POLL_INTERVAL_MS", 5000);
 
 // Feature flags
 const ENABLE_AUTH_MIDDLEWARE = process.env.ENABLE_AUTH_MIDDLEWARE === "true";
 const ENABLE_RATE_LIMITING = process.env.ENABLE_RATE_LIMITING !== "false"; // default to true
 const ENABLE_EXPERIMENTAL_ROUTES = process.env.ENABLE_EXPERIMENTAL_ROUTES === "true";
+
+/** Pass-through middleware used when ENABLE_AUTH_MIDDLEWARE is off. */
+const noopAuthMiddleware: AuthMiddleware = (_req, _res, next) => next();
 
 // ── Database ──────────────────────────────────────────────────────────────────
 
@@ -326,6 +332,8 @@ export async function recoverPendingEvents(handler: RawEventHandler): Promise<nu
     if (await processEvent(event, handler)) recovered += 1;
   }
   return recovered;
+}
+
 /**
  * Wrap a persistence handler so every event's processing outcome is durably
  * recorded on the events table (BA-030) and repeated failures are retained so
@@ -410,7 +418,7 @@ async function main(): Promise<void> {
 
   // BA-039: Bind a per-run correlation context (run id) so all log lines
   // emitted during this process share a groupable correlationId.
-  const runId = crypto.randomUUID();
+  const runId = randomUUID();
   const runLogger = logger.child({ correlationId: runId });
 
   if (replayStartLedger && replayEndLedger) {


### PR DESCRIPTION
## Summary

Three startup values in `Backend/src/index.ts` were substituted with defaults the indexer cannot actually run on, letting the process report itself ready while being permanently unable to index anything:

| Variable | Old behaviour | Problem |
|---|---|---|
| `DATABASE_URL` | fell back to `sqlite::memory:` | every query the indexer issues is PostgreSQL-specific (`TEXT[]`, `TSVECTOR`/GIN, `ON CONFLICT`) |
| `CONTRACT_ID` | fell back to `PLACEHOLDER_CONTRACT_ID` | matches no contract, so the event stream returns nothing forever |
| `START_LEDGER` | `parseInt(value, 10)` | yields `NaN` for `"abc"` and silently truncates `"12abc"` to `12`; the stream config accepted both |

Startup validation now lives in a new side-effect-free module, `Backend/src/config.ts`, and runs before the connection pool, migrations, or any RPC work.

Closes #436 , closes #437 , closes #438 

## What changed

### New: `Backend/src/config.ts`

Pure, dependency-free validation so it is testable without importing the entry point.

**`parseDatabaseUrl`** — required; must parse as a URL with a `postgres:` or `postgresql:` scheme. `sqlite::memory:` is now an explicit error naming PostgreSQL as the only supported engine. Credentials are stripped from error messages so a malformed value cannot leak a password into logs.

**`parseContractId` / `isValidContractId`** — required, and validated as a genuine Stellar contract strkey rather than just shape-checked:

- exactly 56 unpadded base32 (RFC 4648) characters
- decodes to 35 bytes: version byte + 32-byte hash + 2-byte checksum
- contract version byte (`2 << 3` = `16`, which encodes as the leading `C`)
- **CRC16-XModem checksum verified**, little-endian

The checksum is what makes this stronger than a regex — it rejects typos and placeholder-looking values that happen to have the right length and alphabet. The algorithm was cross-checked against two real mainnet contract addresses before being written, and those same addresses are the test fixtures (a hand-written string of the right length would not carry a valid checksum).

**`parseStartLedger`** — `/^\d+$/` plus `Number.isSafeInteger`, replacing `parseInt`. Defaults to `0` only when genuinely unset. Rejects `abc`, `NaN`, `12abc`, `42 ledgers`, `-1`, `+5`, `1.5`, `1e3`, `0x10`, `Infinity`, `1_000`, and values beyond the safe integer range.

**`parseStellarRpcUrl`** — optional (defaults to Soroban testnet) but validated as an `http`/`https` endpoint when set.

**`loadConfig`** — collects *every* problem and throws a single `ConfigError` listing all of them, so a misconfigured deployment is fixed in one pass instead of one restart per mistake.

### `Backend/src/index.ts`

- Replaced the three fallback constants with a destructured `loadStartupConfig()` call at module scope, ahead of `new Pool(...)`. On `ConfigError` it logs `config_invalid` with the problem list, prints the full message, and exits `1`.
- `parseLedger` (used for `REPLAY_START_LEDGER` / `REPLAY_END_LEDGER`) now delegates to `parseStartLedger`, so the replay bounds and `START_LEDGER` cannot drift apart in what they accept.
- Removed the dead `requireEnv` helper, superseded by `config.ts`.
- Corrected the header docblock: `DATABASE_URL` and `CONTRACT_ID` are documented as required; `STELLAR_RPC_URL` and `START_LEDGER` as optional-with-defaults.

### Docs

- `Backend/.env.example` — `CONTRACT_ID` is now empty with a comment explaining it must be a real 56-char `C…` strkey and that startup fails without one. The previous value (`CXXXXXXX…`) was only 49 characters and would now fail validation. `START_LEDGER` documented as optional.
- `Backend/README.md` — runtime-flow step 1 rewritten to describe what is required, what is validated, and what defaults exist.

## Acceptance criteria

**1. Fail startup when PostgreSQL configuration is missing**
- ✅ Missing `DATABASE_URL` fails clearly, with an example connection string in the message
- ✅ Configured PostgreSQL startup remains functional (both `postgres://` and `postgresql://`, including the `docker-compose` host form, are accepted and returned unchanged)
- ✅ Tests cover both paths

**2. Validate the configured contract address**
- ✅ Required, no `PLACEHOLDER_CONTRACT_ID` fallback
- ✅ Validated as a Stellar contract address, including checksum
- ✅ Missing and malformed values both fail before startup, ahead of any pool or RPC work

**3. Reject malformed start ledgers**
- ✅ Only finite non-negative safe integers accepted
- ✅ Regression tests for malformed values (including the exact `parseInt` failure modes: `NaN` and silent truncation) and negative values

## Testing

New suite `Backend/src/__tests__/config.test.ts` — **47 tests, all passing**.

```
PASS src/__tests__/config.test.ts
Tests: 47 passed, 47 total
```

Full suite is unchanged otherwise — the same 8 suites fail before and after this branch (11 failures both times, all pre-existing and unrelated), and passing tests went **63 → 110**.

`tsc --noEmit` reports `src/index.ts` clean.

## Incidental fixes

`src/index.ts` did not compile on `main`, which blocked wiring the config module in at all. Repaired, all within the affected file:

- unterminated header block comment (`//  */.....` left the trailing dots as code)
- `import { Pool } from "pg"` was commented out while `Pool` was still used
- missing closing brace on `recoverPendingEvents`
- `noopAuthMiddleware` was referenced but never defined (it is module-private in `./api`; defined locally rather than widening that module's surface)
- `crypto.randomUUID()` referenced an untyped global under the `ES2020` lib; switched to the already-imported `randomUUID`

## Known out-of-scope blockers

The build is **still broken by files outside this scope**, which I deliberately left untouched to avoid conflicting with other in-flight PRs:

- `src/api/thread.ts:3` — `interface ThreadApi Response` (stray space)
- `src/stream.ts:515,673` — unbalanced braces
- `src/api/contracts.ts` — missing `ApiErrorResponse` / `DebugSnapshot` exports
- `src/db.ts:715` — `searchPosts` signature incompatible with the `Database` interface
- `src/api/__tests__/routes.test.ts:947` — syntax error

Because `index.ts` imports `stream.ts`, `npm run build` still fails and the indexer cannot yet be run end to end. Happy to take these on in a follow-up if they aren't already assigned.
