### PR TITLE
feat(backend): add comprehensive error telemetry (BA-042)

### DIFF
--- a/Backend/src/__tests__/logger.test.ts
+++ b/Backend/src/__tests__/logger.test.ts
@@ -1,0 +1,131 @@
+import {
+  StructuredLogger,
+  redact,
+  getErrorMetrics,
+  resetErrorMetrics,
+} from "../logger";
+
+describe("BA-042 error telemetry", () => {
+  beforeEach(() => {
+    resetErrorMetrics();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("stack traces", () => {
+    it("includes stack, name, message, and code for Error args", () => {
+      const log = new StructuredLogger("test");
+      const err = new Error("boom");
+      (err as Error & { code?: string }).code = "E_TEST";
+
+      log.error("stack_ok", { err });
+
+      const output = (console.error as jest.Mock).mock.calls[0][0] as string;
+      const parsed = JSON.parse(output);
+      expect(parsed.err.name).toBe("Error");
+      expect(parsed.err.message).toBe("boom");
+      expect(parsed.err.code).toBe("E_TEST");
+      expect(typeof parsed.err.stack).toBe("string");
+      expect(parsed.err.stack).toContain("Error: boom");
+    });
+
+    it("truncates oversized stacks to a bounded tail", () => {
+      const log = new StructuredLogger("test");
+      const err = new Error("big");
+      err.stack = "E".repeat(10000);
+
+      log.error("stack_big", { err });
+
+      const parsed = JSON.parse((console.error as jest.Mock).mock.calls[0][0]);
+      expect(parsed.err.stack.length).toBe(2048 + "...(truncated)".length);
+      expect(parsed.err.stack.startsWith("E")).toBe(true);
+      expect(parsed.err.stack.endsWith("...(truncated)")).toBe(true);
+    });
+
+    it("omits stack when the Error has none", () => {
+      const log = new StructuredLogger("test");
+      const err = new Error("no stack");
+      err.stack = undefined;
+
+      log.error("stack_none", { err });
+
+      const parsed = JSON.parse((console.error as jest.Mock).mock.calls[0][0]);
+      expect(parsed.err.stack).toBeUndefined();
+    });
+  });
+
+  describe("error metrics", () => {
+    it("counts error and warn events by code and message key", () => {
+      const log = new StructuredLogger("test");
+      const errA = new Error("a");
+      (errA as Error & { code?: string }).code = "E_A";
+      const errB = new Error("b");
+
+      log.error("first_failure", { err: errA });
+      log.error("second_failure", { err: errA });
+      log.error("third_failure", { err: errB });
+      log.warn("fourth_warning", { err: errA });
+
+      const metrics = getErrorMetrics();
+      expect(metrics.total).toBe(4);
+      expect(metrics.byCode["E_A"]).toBe(3); // 2 errors + 1 warn
+      expect(metrics.byCode["<unknown>"]).toBe(1);
+      expect(metrics.byMessage.first_failure).toBe(1);
+      expect(metrics.byMessage.second_failure).toBe(1);
+      expect(metrics.byMessage.third_failure).toBe(1);
+      expect(metrics.byMessage.fourth_warning).toBe(1);
+    });
+
+    it("excludes always() and info() from metrics", () => {
+      const log = new StructuredLogger("test");
+      log.always("info_line", { err: new Error("x") });
+      log.info("info_line2");
+
+      expect(getErrorMetrics().total).toBe(0);
+    });
+
+    it("resets cleanly", () => {
+      const log = new StructuredLogger("test");
+      log.error("reset_check", { err: new Error("x") });
+      resetErrorMetrics();
+      expect(getErrorMetrics().total).toBe(0);
+    });
+
+    it("caps tracked message keys to prevent unbounded growth", () => {
+      const log = new StructuredLogger("test");
+      for (let i = 0; i < 150; i++) {
+        log.error(`msg_key_${i}`);
+      }
+      const metrics = getErrorMetrics();
+      expect(Object.keys(metrics.byMessage).length).toBeLessThanOrEqual(100);
+      expect(metrics.byMessage.msg_key_0).toBeUndefined(); // oldest evicted
+      expect(metrics.byMessage.msg_key_149).toBe(1);
+    });
+
+    it("does not double-count deduplicated (suppressed) lines", () => {
+      const log = new StructuredLogger("test");
+      log.error("dedup_check", { err: new Error("x") });
+      log.error("dedup_check", { err: new Error("x") }); // suppressed by dedup window
+
+      expect(getErrorMetrics().total).toBe(1);
+    });
+  });
+
+  describe("existing redaction behaviour (regression)", () => {
+    it("still redacts nested values and keeps bounded messages", () => {
+      const err = new Error("x");
+      err.stack = "at f ()";
+      const out = redact({ err, address: "G".repeat(56) }) as Record<
+        string,
+        unknown
+      >;
+      expect((out.err as { stack?: string }).stack).toBe("at f ()");
+      expect(out.address).not.toBe("G".repeat(56));
+    });
+  });
+});

--- a/Backend/src/logger.ts
+++ b/Backend/src/logger.ts
@@ -9,6 +9,11 @@
  *   - Redaction masks Stellar addresses and opaque event payloads before they
  *     reach the console, preventing sensitive values from leaking into logs.
  *
+ * BA-042: Error telemetry — every `error()`/`warn()` line carries a bounded
+ * stack trace and error code (when present), and all error/warn events are
+ * counted into in-memory metrics (`getErrorMetrics()`) keyed by error code
+ * and message, for debugging production issues without a log aggregator.
+ *
  * Backwards-compatible with the previous `logger.info/warn/error/always`
  * surface, so existing call sites keep working without modification.
  */
@@ -46,6 +51,10 @@ const ADDRESS_KEEP_HEAD = 6;
 const ADDRESS_KEEP_TAIL = 4;
 /** Opaque payloads longer than this are truncated to avoid leaking the body. */
 const PAYLOAD_MAX_LEN = 64;
+/** Maximum stack-trace length kept in a log line (BA-042). */
+const STACK_MAX_LEN = 2048;
+/** Maximum distinct message keys tracked by error metrics (BA-042). */
+const METRICS_MAX_KEYS = 100;
 
 /**
  * Mask a Stellar-style address (e.g. `GABCDE...WXYZ`) so its identity is
@@ -86,16 +95,19 @@ export function redactValue(value: unknown): unknown {
 export function redact(arg: unknown, depth = 0): unknown {
   if (depth > 6) return "<max-depth>";
   if (arg instanceof Error) {
-    // Keep the essential, bounded error context without dumping stack or
-    // sensitive payload fields that might be stashed on the error object.
+    // Keep the essential, bounded error context without dumping sensitive
+    // payload fields that might be stashed on the error object.
+    // BA-042: the stack IS kept (bounded) so production failures are debuggable.
     const message = String(arg.message);
     const bounded =
       message.length > 256 ? `${message.slice(0, 256)}...(truncated)` : message;
     const code = (arg as Error & { code?: unknown }).code;
+    const stack = arg.stack ? boundStack(arg.stack) : undefined;
     return {
       name: arg.name,
       message: redactValue(bounded),
       ...(code !== undefined ? { code: redactValue(code) } : {}),
+      ...(stack !== undefined ? { stack } : {}),
     };
   }
   if (typeof arg === "string") return redactValue(arg);
@@ -108,6 +120,88 @@ export function redact(arg: unknown, depth = 0): unknown {
     return out;
   }
   return arg;
+}
+
+/**
+ * Bound a stack trace to a fixed maximum length (BA-042): keep the head
+ * (error type + message + first frames) and mark the truncation.
+ */
+function boundStack(stack: string): string {
+  if (stack.length <= STACK_MAX_LEN) return stack;
+  return `${stack.slice(0, STACK_MAX_LEN)}...(truncated)`;
+}
+
+// ── Error metrics (BA-042) ──────────────────────────────────────────────────
+
+interface ErrorMetricsSnapshot {
+  /** Total error+warn events counted since process start (or last reset). */
+  total: number;
+  /** Events per error code (or "<unknown>" when the error has no code). */
+  byCode: Record<string, number>;
+  /** Events per log message key. */
+  byMessage: Record<string, number>;
+}
+
+const errorMetrics = {
+  total: 0,
+  byCode: new Map<string, number>(),
+  byMessage: new Map<string, number>(),
+};
+
+function bumpMetric(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+  // Bound memory: once over the cap, drop the oldest tracked key.
+  if (map.size > METRICS_MAX_KEYS) {
+    const oldest = map.keys().next().value;
+    if (oldest !== undefined) map.delete(oldest);
+  }
+}
+
+function recordErrorMetric(level: string, message: string, args: unknown[]): void {
+  if (level !== "error" && level !== "warn") return;
+  errorMetrics.total += 1;
+  // Find the first Error arg (raw, before redaction) to read its code.
+  // Errors are usually passed either directly or nested one level in an
+  // object (e.g. `{ err }`), so check both shapes.
+  let code;
+  for (const arg of args) {
+    if (arg instanceof Error) {
+      code = (arg as Error & { code?: unknown }).code;
+      break;
+    }
+    if (arg && typeof arg === "object" && !Array.isArray(arg)) {
+      const nested = Object.values(arg as Record<string, unknown>)
+        .find((v) => v instanceof Error) as Error | undefined;
+      if (nested) {
+        code = (nested as Error & { code?: unknown }).code;
+        break;
+      }
+    }
+  }
+  bumpMetric(
+    errorMetrics.byCode,
+    code !== undefined ? String(code) : "<unknown>"
+  );
+  bumpMetric(errorMetrics.byMessage, message);
+}
+
+/**
+ * Snapshot of in-memory error counters (BA-042). Exposed for health/debug
+ * endpoints and tests; safe to call from any logger instance.
+ */
+export function getErrorMetrics(): ErrorMetricsSnapshot {
+  return {
+    total: errorMetrics.total,
+    byCode: Object.fromEntries(errorMetrics.byCode),
+    byMessage: Object.fromEntries(errorMetrics.byMessage),
+  };
+}
+
+/** Reset error counters (used by tests; also handy for long-lived processes). */
+export function resetErrorMetrics(): void {
+  errorMetrics.total = 0;
+  errorMetrics.byCode.clear();
+  errorMetrics.byMessage.clear();
 }
 
 // ── Logger ──────────────────────────────────────────────────────────────────
@@ -159,11 +253,17 @@ export class StructuredLogger implements Logger {
   }
 
   warn(message: string, ...args: unknown[]): void {
-    if (shouldLog(logKey("warn", message))) this.write("warn", message, args);
+    if (shouldLog(logKey("warn", message))) {
+      recordErrorMetric("warn", message, args);
+      this.write("warn", message, args);
+    }
   }
 
   error(message: string, ...args: unknown[]): void {
-    if (shouldLog(logKey("error", message))) this.write("error", message, args);
+    if (shouldLog(logKey("error", message))) {
+      recordErrorMetric("error", message, args);
+      this.write("error", message, args);
+    }
   }
 
   always(message: string, ...args: unknown[]): void {


### PR DESCRIPTION
Closes #617

## Summary

Implements **BA-042 — Add comprehensive error telemetry** for the indexer's logging layer (`Backend/src/logger.ts`), as assigned for the Stellar Wave Program (8th wave).

## Changes

### 1. Stack traces (previously dropped)
`redact()` intentionally discarded stack traces, which made production failures undebuggable. Errors now carry a **bounded stack trace (2 KB cap)** in structured output, so the failure origin is visible without unbounded log growth.

### 2. Error codes
Error `code` properties (e.g. `ECONNREFUSED`, custom codes) now flow through redaction into the structured JSON output alongside `name`/`message`/`stack`.

### 3. Error metrics
New in-memory counters exposed via `getErrorMetrics()` / reset via `resetErrorMetrics()`:
- `total` — all error+warn events
- `byCode` — events per error code (`<unknown>` when absent)
- `byMessage` — events per log message key

Design notes:
- Capped at 100 keys per map (oldest evicted) to bound memory in long-lived processes
- Respects the existing dedup window — suppressed repeat lines are **not** double-counted
- `info`/`always` levels are excluded from metrics
- Zero new dependencies

### 4. Tests
`Backend/src/__tests__/logger.test.ts` — 9 tests covering stack inclusion/truncation/omission, metric counting, level filtering, reset, key capping, dedup interaction, and redaction regression. **All 9 pass.**

## Verification

- ✅ `npx jest src/__tests__/logger.test.ts` — 9/9 pass
- ✅ `tsc --noEmit` — no new errors from this change (see note below)
- ✅ No new lint errors

## ⚠️ Note on pre-existing failures (not from this PR)

While verifying, I found breakage that **already exists on `main`** and will fail CI independently of this PR (verified via `git stash` → `tsc` on a clean tree):

- `src/api/thread.ts(3,28)` — syntax error (`export interface ThreadApi Response{`)
- `src/stream.ts(515, 673)` — unbalanced braces / dangling `logger.always("Stopped.")` after `replayEventTypes()`
- `src/db.ts(715)` — `searchPosts` overload signature incompatible with base `Database` type (breaks `toSafeBigInt.test.ts` suite compilation)
- `src/api/contracts.ts` — missing exports `ApiErrorResponse` / `DebugSnapshot` (breaks smoke/rate-limit suites)
- `src/api/__tests__/routes.test.ts(39)` — stray `async getRecommendation(...)` outside a class
- `src/api/__tests__/search.test.ts` — `body` typed `unknown` (needs type assertion)

I've kept this PR scoped to BA-042 per the issue, but maintainers may want follow-up issues for the above. Happy to address them in a separate PR if preferred.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>